### PR TITLE
Add GDPR compliant privacy and cookie policy plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# FP-Privacy-and-Cookie-Policy
+# FP Privacy and Cookie Policy
+
+Plugin WordPress progettato per gestire privacy policy, cookie policy e consenso informato nel rispetto del GDPR, con particolare attenzione alle esigenze dei siti italiani e all'integrazione del Google Consent Mode v2.
+
+## Funzionalità principali
+
+- Banner cookie responsive con pulsanti "Accetta", "Rifiuta" e accesso rapido alle preferenze.
+- Gestione delle categorie di cookie (necessari, preferenze, statistiche, marketing) e descrizione dei servizi utilizzati.
+- Editor WYSIWYG per i testi di privacy e cookie policy e shortcodes dedicati.
+- Registro consensi con anonimizzazione IP, esportazione in CSV e conservazione degli eventi di scelta.
+- Integrazione automatica con Google Consent Mode v2 (`analytics_storage`, `ad_storage`, `ad_user_data`, `ad_personalization`, `functionality_storage`, `security_storage`).
+- Supporto per Google Tag Manager/eventi personalizzati via `dataLayer` e custom event `fp-consent-change`.
+
+## Installazione
+
+1. Copia la cartella `fp-privacy-cookie-policy` all'interno di `wp-content/plugins/`.
+2. Accedi alla bacheca WordPress e attiva **FP Privacy and Cookie Policy** dal menu "Plugin".
+3. Alla prima attivazione viene creata automaticamente la tabella del registro consensi.
+
+## Configurazione rapida
+
+1. Vai su **Privacy & Cookie** nel menu laterale della bacheca.
+2. Aggiorna i testi di Privacy e Cookie Policy con l'editor visuale. Puoi usare gli shortcode per richiamarli in qualsiasi pagina:
+   - `[fp_privacy_policy]`
+   - `[fp_cookie_policy]`
+   - `[fp_cookie_preferences]` (pulsante per riaprire le preferenze)
+3. Configura il banner cookie (titolo, messaggio, etichette pulsanti) e decidi se mostrare il pulsante di rifiuto e quello delle preferenze.
+4. Per ciascuna categoria indica descrizione, servizi e durata dei cookie utilizzati. Le categorie obbligatorie sono marcate come "Sempre attivo" nel front-end.
+5. Imposta i valori di default del Google Consent Mode v2 scegliendo tra `granted` o `denied` per ciascun segnale.
+
+## Google Consent Mode v2
+
+- Il plugin invia i segnali di default tramite `gtag('consent', 'default', {...})` e aggiorna automaticamente gli stati al salvataggio delle preferenze (`consent`, `accept_all`, `reject_all`).
+- Gli eventi vengono tracciati su `window.dataLayer` con `event: 'fp_consent_update'` e i dettagli dell'ultima scelta.
+- Per utilizzare Google Tag Manager o gtag.js assicurati che lo script sia caricato **dopo** il banner (ad esempio nell'`head`) e che non imposti manualmente il consent mode in conflitto con il plugin.
+- Puoi ascoltare l'evento JavaScript personalizzato `fp-consent-change` per abilitare/disabilitare altri script di terze parti in base alle categorie selezionate.
+
+## Registro consensi
+
+- Nella tab **Registro consensi** trovi gli ultimi eventi registrati (50 per pagina) con data, ID consenso, stato e IP anonimizzato.
+- È possibile esportare l'intero registro in formato CSV per adempiere agli obblighi di accountability.
+- Gli ID consenso sono conservati in un cookie tecnico sicuro e anonimo (`fp_consent_state_id`).
+
+## Suggerimenti legali
+
+Questo plugin fornisce strumenti tecnici ma non sostituisce la consulenza legale. Per la piena conformità al GDPR:
+
+- Aggiorna periodicamente le informative e i registri in base ai trattamenti effettivi.
+- Notifica agli utenti eventuali cambiamenti nelle finalità o nei partner terzi e raccogli nuovamente il consenso quando necessario.
+- Imposta procedure interne per gestire le richieste degli interessati (accesso, rettifica, cancellazione, portabilità, ecc.).
+
+## Supporto
+
+Il plugin è pensato per sviluppatori e web agency. Puoi estenderlo registrando nuovi hook su `fp-consent-change` o leggendo il cookie `fp_consent_state` per gestire script personalizzati.

--- a/fp-privacy-cookie-policy/assets/css/admin.css
+++ b/fp-privacy-cookie-policy/assets/css/admin.css
@@ -1,0 +1,41 @@
+.fp-privacy-admin .fp-banner-settings,
+.fp-privacy-admin .fp-categories fieldset {
+    background: #fff;
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    padding: 1.25rem;
+    margin-bottom: 1.5rem;
+}
+
+.fp-privacy-admin .fp-banner-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1rem;
+}
+
+.fp-privacy-admin .fp-categories {
+    display: grid;
+    gap: 1.25rem;
+}
+
+.fp-privacy-admin .fp-category legend {
+    font-size: 1rem;
+}
+
+.fp-consent-log-table code {
+    background: #f3f4f6;
+    padding: 0.1rem 0.3rem;
+    border-radius: 4px;
+}
+
+.fp-consent-log-actions {
+    margin: 1rem 0;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.fp-help-tab code {
+    background: #f3f4f6;
+    padding: 0.2rem 0.45rem;
+    border-radius: 4px;
+}

--- a/fp-privacy-cookie-policy/assets/css/banner.css
+++ b/fp-privacy-cookie-policy/assets/css/banner.css
@@ -1,0 +1,278 @@
+.fp-consent-banner {
+    position: fixed;
+    left: 1.5rem;
+    right: 1.5rem;
+    bottom: 1.5rem;
+    z-index: 9999;
+    background: #ffffff;
+    color: #1f2933;
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.18);
+    border-radius: 12px;
+    padding: 1.75rem;
+    display: none;
+    font-family: inherit;
+}
+
+.fp-consent-banner.is-visible {
+    display: block;
+}
+
+.fp-consent-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.fp-consent-content {
+    flex: 1 1 320px;
+    min-width: 260px;
+}
+
+.fp-consent-title {
+    margin: 0 0 0.35rem;
+    font-size: 1.25rem;
+    font-weight: 700;
+}
+
+.fp-consent-text {
+    font-size: 0.95rem;
+    line-height: 1.6;
+}
+
+.fp-consent-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.fp-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 6px;
+    padding: 0.6rem 1.3rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    text-decoration: none;
+    transition: background 0.2s ease, color 0.2s ease, transform 0.15s ease;
+    border: none;
+}
+
+.fp-btn:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+}
+
+.fp-btn-primary {
+    background: #2563eb;
+    color: #ffffff;
+}
+
+.fp-btn-primary:hover,
+.fp-btn-primary:focus {
+    background: #1d4ed8;
+}
+
+.fp-btn-secondary {
+    background: #eef2ff;
+    color: #1e3a8a;
+}
+
+.fp-btn-secondary:hover,
+.fp-btn-secondary:focus {
+    background: #e0e7ff;
+}
+
+.fp-btn-tertiary,
+.fp-btn-preferences {
+    background: transparent;
+    color: #2563eb;
+    border: 1px solid #2563eb;
+}
+
+.fp-btn-tertiary:hover,
+.fp-btn-tertiary:focus,
+.fp-btn-preferences:hover,
+.fp-btn-preferences:focus {
+    background: rgba(37, 99, 235, 0.12);
+}
+
+.fp-consent-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 10000;
+    display: none;
+}
+
+.fp-consent-modal.is-visible {
+    display: block;
+}
+
+.fp-consent-modal__overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+}
+
+.fp-consent-modal__dialog {
+    position: relative;
+    max-width: 720px;
+    margin: 5vh auto;
+    background: #ffffff;
+    border-radius: 14px;
+    padding: 2rem 2.5rem;
+    max-height: 90vh;
+    overflow-y: auto;
+    box-shadow: 0 30px 60px rgba(15, 23, 42, 0.25);
+}
+
+.fp-consent-modal__close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    background: transparent;
+    border: none;
+    font-size: 1.75rem;
+    line-height: 1;
+    cursor: pointer;
+    color: #475569;
+}
+
+.fp-consent-modal__intro {
+    color: #475569;
+    line-height: 1.6;
+}
+
+.fp-consent-categories {
+    margin-top: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.fp-consent-category {
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    padding: 1rem 1.25rem;
+    background: #f8fafc;
+}
+
+.fp-consent-category__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1.25rem;
+}
+
+.fp-consent-category h4 {
+    margin: 0 0 0.35rem;
+    font-size: 1.05rem;
+}
+
+.fp-consent-category p {
+    margin: 0 0 0.35rem;
+    color: #475569;
+    line-height: 1.55;
+}
+
+.fp-consent-category details {
+    margin-top: 0.4rem;
+}
+
+.fp-consent-required {
+    display: inline-flex;
+    align-items: center;
+    font-weight: 600;
+    color: #1e293b;
+    background: #e2e8f0;
+    padding: 0.3rem 0.6rem;
+    border-radius: 9999px;
+    font-size: 0.78rem;
+}
+
+.fp-consent-toggle {
+    display: flex;
+    align-items: center;
+    min-width: 120px;
+    justify-content: flex-end;
+}
+
+.fp-switch {
+    position: relative;
+    display: inline-block;
+    width: 48px;
+    height: 26px;
+}
+
+.fp-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.fp-slider {
+    position: absolute;
+    cursor: pointer;
+    inset: 0;
+    background-color: #cbd5f5;
+    transition: 0.3s;
+    border-radius: 9999px;
+}
+
+.fp-slider::before {
+    position: absolute;
+    content: '';
+    height: 20px;
+    width: 20px;
+    left: 4px;
+    bottom: 3px;
+    background-color: white;
+    transition: 0.3s;
+    border-radius: 50%;
+    box-shadow: 0 3px 8px rgba(15, 23, 42, 0.25);
+}
+
+.fp-switch input:checked + .fp-slider {
+    background-color: #2563eb;
+}
+
+.fp-switch input:checked + .fp-slider::before {
+    transform: translateX(20px);
+}
+
+.fp-consent-modal__actions {
+    margin-top: 1.75rem;
+    display: flex;
+    gap: 0.75rem;
+    justify-content: flex-end;
+}
+
+.fp-consent-modal-open {
+    overflow: hidden;
+}
+
+@media (max-width: 768px) {
+    .fp-consent-banner {
+        left: 1rem;
+        right: 1rem;
+        bottom: 1rem;
+        padding: 1.25rem;
+    }
+
+    .fp-consent-modal__dialog {
+        margin: 10vh 1rem;
+        padding: 1.5rem;
+    }
+
+    .fp-consent-category__header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .fp-consent-toggle {
+        justify-content: flex-start;
+    }
+}

--- a/fp-privacy-cookie-policy/assets/js/fp-consent.js
+++ b/fp-privacy-cookie-policy/assets/js/fp-consent.js
@@ -1,0 +1,343 @@
+(function () {
+    'use strict';
+
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    var settings = window.fpPrivacySettings || {};
+    var cookieName = settings.cookieName || 'fp_consent_state';
+    var consentId = settings.consentId || '';
+    var categories = settings.categories || {};
+    var googleDefaults = settings.googleDefaults || {};
+    var requiredKeys = Object.keys(categories).filter(function (key) {
+        return categories[key] && categories[key].required;
+    });
+    var enabledKeys = Object.keys(categories).filter(function (key) {
+        return categories[key] && (categories[key].enabled || categories[key].required);
+    });
+    var bannerElement;
+    var modalElement;
+    var currentConsent = null;
+
+    document.addEventListener('DOMContentLoaded', initialize);
+
+    function initialize() {
+        bannerElement = document.querySelector('.fp-consent-banner');
+        modalElement = document.querySelector('.fp-consent-modal');
+
+        ensureGtag();
+        if (googleDefaults && Object.keys(googleDefaults).length) {
+            window.gtag('consent', 'default', googleDefaults);
+        }
+
+        currentConsent = getStoredConsent();
+
+        if (currentConsent) {
+            applyConsentToInterface(currentConsent);
+            var mapped = updateGoogleConsent(currentConsent, true);
+            pushDataLayer(currentConsent, mapped);
+            hideBanner();
+        } else {
+            currentConsent = buildDefaultConsent();
+            showBanner();
+        }
+
+        bindActions();
+    }
+
+    function bindActions() {
+        document.addEventListener('click', function (event) {
+            var target = event.target.closest('[data-consent-action]');
+            if (!target) {
+                return;
+            }
+
+            var action = target.getAttribute('data-consent-action');
+
+            switch (action) {
+                case 'accept-all':
+                    event.preventDefault();
+                    handleAcceptAll();
+                    break;
+                case 'reject-all':
+                    event.preventDefault();
+                    handleRejectAll();
+                    break;
+                case 'open-preferences':
+                    event.preventDefault();
+                    openModal();
+                    break;
+                case 'save-preferences':
+                    event.preventDefault();
+                    handleSavePreferences();
+                    break;
+                case 'close':
+                    event.preventDefault();
+                    closeModal();
+                    break;
+                default:
+                    break;
+            }
+        });
+    }
+
+    function handleAcceptAll() {
+        var state = {};
+        enabledKeys.forEach(function (key) {
+            state[key] = true;
+        });
+        requiredKeys.forEach(function (key) {
+            state[key] = true;
+        });
+        saveConsent(state, 'accept_all');
+    }
+
+    function handleRejectAll() {
+        var state = buildDefaultConsent();
+        saveConsent(state, 'reject_all');
+    }
+
+    function handleSavePreferences() {
+        if (!modalElement) {
+            return;
+        }
+
+        var toggles = modalElement.querySelectorAll('[data-category-toggle]');
+        var state = buildDefaultConsent();
+
+        toggles.forEach(function (toggle) {
+            var key = toggle.getAttribute('data-category-toggle');
+            if (!key) {
+                return;
+            }
+            state[key] = toggle.checked;
+        });
+
+        requiredKeys.forEach(function (key) {
+            state[key] = true;
+        });
+
+        saveConsent(state, 'save_preferences');
+    }
+
+    function buildDefaultConsent() {
+        var defaults = {};
+        Object.keys(categories).forEach(function (key) {
+            var cat = categories[key];
+            defaults[key] = !!(cat && cat.required);
+        });
+        return defaults;
+    }
+
+    function getStoredConsent() {
+        try {
+            var cookie = readCookie(cookieName);
+            if (!cookie) {
+                return null;
+            }
+            var parsed = JSON.parse(cookie);
+            if (parsed && typeof parsed === 'object') {
+                return parsed;
+            }
+        } catch (error) {
+            console.warn('[FP Privacy] Unable to parse consent cookie', error);
+        }
+        return null;
+    }
+
+    function saveConsent(state, eventType) {
+        if (!state) {
+            return;
+        }
+
+        requiredKeys.forEach(function (key) {
+            state[key] = true;
+        });
+
+        currentConsent = state;
+        applyConsentToInterface(state);
+        storeConsentCookie(state);
+        updateGoogleConsent(state, false);
+        hideBanner();
+        closeModal();
+        dispatchConsentEvent(state, eventType);
+        sendConsentToServer(state, eventType);
+    }
+
+    function applyConsentToInterface(state) {
+        if (!modalElement) {
+            modalElement = document.querySelector('.fp-consent-modal');
+        }
+
+        if (!modalElement) {
+            return;
+        }
+
+        var toggles = modalElement.querySelectorAll('[data-category-toggle]');
+        toggles.forEach(function (toggle) {
+            var key = toggle.getAttribute('data-category-toggle');
+            if (!key || requiredKeys.indexOf(key) !== -1) {
+                toggle.checked = true;
+                return;
+            }
+            toggle.checked = !!state[key];
+        });
+    }
+
+    function updateGoogleConsent(state, silent) {
+        var mapped = mapStateToGoogle(state);
+
+        if (typeof window.gtag === 'function') {
+            window.gtag('consent', 'update', mapped);
+        }
+
+        if (!silent) {
+            pushDataLayer(state, mapped);
+        }
+
+        return mapped;
+    }
+
+    function mapStateToGoogle(state) {
+        var consent = state || {};
+        var analyticsGranted = !!consent.statistics;
+        var marketingGranted = !!consent.marketing;
+        var preferencesGranted = !!consent.preferences;
+        var necessaryGranted = !!consent.necessary;
+
+        var mapped = Object.assign({}, googleDefaults);
+        mapped.analytics_storage = analyticsGranted ? 'granted' : 'denied';
+        mapped.ad_storage = marketingGranted ? 'granted' : 'denied';
+        mapped.ad_user_data = marketingGranted ? 'granted' : 'denied';
+        mapped.ad_personalization = marketingGranted ? 'granted' : 'denied';
+        mapped.functionality_storage = (preferencesGranted || necessaryGranted) ? 'granted' : 'denied';
+        mapped.security_storage = necessaryGranted ? 'granted' : 'denied';
+
+        return mapped;
+    }
+
+    function pushDataLayer(state, googleState) {
+        window.dataLayer = window.dataLayer || [];
+        window.dataLayer.push({
+            event: 'fp_consent_update',
+            consent_id: consentId,
+            consent_state: Object.assign({}, state),
+            google_consent: Object.assign({}, googleState || {}),
+            consent_timestamp: new Date().toISOString()
+        });
+    }
+
+    function sendConsentToServer(state, eventType) {
+        if (!settings.ajaxUrl || !settings.nonce) {
+            return;
+        }
+
+        var params = new URLSearchParams();
+        params.append('action', 'fp_save_consent');
+        params.append('nonce', settings.nonce);
+        params.append('consentId', consentId);
+        params.append('event', eventType);
+
+        Object.keys(state).forEach(function (key) {
+            params.append('consent[' + key + ']', state[key] ? '1' : '0');
+        });
+
+        fetch(settings.ajaxUrl, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+            },
+            body: params.toString()
+        }).catch(function (error) {
+            console.warn('[FP Privacy] Unable to log consent', error);
+        });
+    }
+
+    function storeConsentCookie(state) {
+        var value = encodeURIComponent(JSON.stringify(state));
+        var attributes = ['path=/','max-age=' + 60 * 60 * 24 * 365,'SameSite=Lax'];
+        if (window.location && window.location.protocol === 'https:') {
+            attributes.push('Secure');
+        }
+        document.cookie = cookieName + '=' + value + ';' + attributes.join(';');
+    }
+
+    function readCookie(name) {
+        var nameEQ = name + '=';
+        var ca = document.cookie ? document.cookie.split(';') : [];
+        for (var i = 0; i < ca.length; i++) {
+            var c = ca[i].trim();
+            if (c.indexOf(nameEQ) === 0) {
+                return decodeURIComponent(c.substring(nameEQ.length, c.length));
+            }
+        }
+        return null;
+    }
+
+    function openModal() {
+        if (!modalElement) {
+            modalElement = document.querySelector('.fp-consent-modal');
+        }
+        if (!modalElement) {
+            return;
+        }
+        applyConsentToInterface(currentConsent || buildDefaultConsent());
+        modalElement.hidden = false;
+        modalElement.classList.add('is-visible');
+        document.body.classList.add('fp-consent-modal-open');
+    }
+
+    function closeModal() {
+        if (!modalElement) {
+            return;
+        }
+        modalElement.hidden = true;
+        modalElement.classList.remove('is-visible');
+        document.body.classList.remove('fp-consent-modal-open');
+    }
+
+    function showBanner() {
+        if (!bannerElement) {
+            bannerElement = document.querySelector('.fp-consent-banner');
+        }
+        if (bannerElement) {
+            bannerElement.classList.add('is-visible');
+        }
+    }
+
+    function hideBanner() {
+        if (!bannerElement) {
+            bannerElement = document.querySelector('.fp-consent-banner');
+        }
+        if (bannerElement) {
+            bannerElement.classList.remove('is-visible');
+        }
+    }
+
+    function dispatchConsentEvent(state, eventType) {
+        var detail = {
+            consentId: consentId,
+            state: Object.assign({}, state),
+            eventType: eventType
+        };
+        var event;
+        try {
+            event = new CustomEvent('fp-consent-change', { detail: detail });
+        } catch (e) {
+            event = document.createEvent('CustomEvent');
+            event.initCustomEvent('fp-consent-change', true, true, detail);
+        }
+        document.dispatchEvent(event);
+    }
+
+    function ensureGtag() {
+        window.dataLayer = window.dataLayer || [];
+        if (typeof window.gtag !== 'function') {
+            window.gtag = function () {
+                window.dataLayer.push(arguments);
+            };
+        }
+    }
+})();

--- a/fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
+++ b/fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
@@ -1,0 +1,1015 @@
+<?php
+/**
+ * Plugin Name: FP Privacy and Cookie Policy
+ * Plugin URI:  https://example.com/
+ * Description: Gestisci privacy policy, cookie policy e consenso informato in modo conforme al GDPR e al Google Consent Mode v2.
+ * Version:     1.0.0
+ * Author:      FP Digital Assistant
+ * Author URI:  https://example.com/
+ * License:     GPL2
+ * Text Domain: fp-privacy-cookie-policy
+ * Domain Path: /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'FP_Privacy_Cookie_Policy' ) ) {
+
+    class FP_Privacy_Cookie_Policy {
+
+        const OPTION_KEY        = 'fp_privacy_cookie_settings';
+        const VERSION           = '1.0.0';
+        const CONSENT_COOKIE    = 'fp_consent_state';
+        const CONSENT_TABLE     = 'fp_consent_logs';
+        const NONCE_ACTION      = 'fp_privacy_nonce';
+
+        /**
+         * Singleton instance.
+         *
+         * @var FP_Privacy_Cookie_Policy|null
+         */
+        protected static $instance = null;
+
+        /**
+         * Get singleton instance.
+         *
+         * @return FP_Privacy_Cookie_Policy
+         */
+        public static function instance() {
+            if ( null === self::$instance ) {
+                self::$instance = new self();
+            }
+
+            return self::$instance;
+        }
+
+        /**
+         * FP_Privacy_Cookie_Policy constructor.
+         */
+        private function __construct() {
+            add_action( 'init', array( $this, 'load_textdomain' ) );
+            add_action( 'admin_menu', array( $this, 'register_admin_menu' ) );
+            add_action( 'admin_init', array( $this, 'register_settings' ) );
+            add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
+            add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_assets' ) );
+            add_action( 'wp_footer', array( $this, 'render_consent_banner' ) );
+            add_action( 'init', array( $this, 'register_shortcodes' ) );
+            add_action( 'wp_ajax_fp_save_consent', array( $this, 'ajax_save_consent' ) );
+            add_action( 'wp_ajax_nopriv_fp_save_consent', array( $this, 'ajax_save_consent' ) );
+            add_action( 'admin_post_fp_export_consent', array( $this, 'export_consent_logs' ) );
+        }
+
+        /**
+         * Load textdomain.
+         */
+        public function load_textdomain() {
+            load_plugin_textdomain( 'fp-privacy-cookie-policy', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+        }
+
+        /**
+         * Register activation hook.
+         */
+        public static function activate() {
+            self::create_consent_table();
+        }
+
+        /**
+         * Create consent logs table.
+         */
+        public static function create_consent_table() {
+            global $wpdb;
+
+            $table_name      = $wpdb->prefix . self::CONSENT_TABLE;
+            $charset_collate = $wpdb->get_charset_collate();
+
+            require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+            $sql = "CREATE TABLE {$table_name} (
+                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                consent_id VARCHAR(64) NOT NULL,
+                user_id BIGINT UNSIGNED DEFAULT NULL,
+                event_type VARCHAR(20) NOT NULL,
+                consent_state LONGTEXT NOT NULL,
+                ip_address VARCHAR(100) DEFAULT NULL,
+                user_agent TEXT DEFAULT NULL,
+                created_at DATETIME NOT NULL,
+                PRIMARY KEY  (id),
+                KEY consent_id (consent_id)
+            ) {$charset_collate};";
+
+            dbDelta( $sql );
+        }
+
+        /**
+         * Register deactivation hook.
+         */
+        public static function deactivate() {
+            // Nothing to do for now.
+        }
+
+        /**
+         * Register uninstall hook.
+         */
+        public static function uninstall() {
+            delete_option( self::OPTION_KEY );
+
+            global $wpdb;
+
+            $table_name = $wpdb->prefix . self::CONSENT_TABLE;
+            $wpdb->query( "DROP TABLE IF EXISTS {$table_name}" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+        }
+
+        /**
+         * Register admin menu.
+         */
+        public function register_admin_menu() {
+            add_menu_page(
+                __( 'Privacy & Cookie', 'fp-privacy-cookie-policy' ),
+                __( 'Privacy & Cookie', 'fp-privacy-cookie-policy' ),
+                'manage_options',
+                'fp-privacy-cookie-policy',
+                array( $this, 'render_settings_page' ),
+                'dashicons-shield-alt',
+                82
+            );
+        }
+
+        /**
+         * Register plugin settings.
+         */
+        public function register_settings() {
+            register_setting(
+                'fp_privacy_cookie_group',
+                self::OPTION_KEY,
+                array( $this, 'sanitize_settings' )
+            );
+
+            add_settings_section(
+                'fp_privacy_general_section',
+                __( 'Impostazioni generali', 'fp-privacy-cookie-policy' ),
+                '__return_false',
+                'fp_privacy_cookie_policy'
+            );
+
+            add_settings_field(
+                'privacy_policy_content',
+                __( 'Privacy Policy', 'fp-privacy-cookie-policy' ),
+                array( $this, 'render_privacy_editor' ),
+                'fp_privacy_cookie_policy',
+                'fp_privacy_general_section'
+            );
+
+            add_settings_field(
+                'cookie_policy_content',
+                __( 'Cookie Policy', 'fp-privacy-cookie-policy' ),
+                array( $this, 'render_cookie_editor' ),
+                'fp_privacy_cookie_policy',
+                'fp_privacy_general_section'
+            );
+
+            add_settings_field(
+                'banner_settings',
+                __( 'Banner Cookie', 'fp-privacy-cookie-policy' ),
+                array( $this, 'render_banner_settings' ),
+                'fp_privacy_cookie_policy',
+                'fp_privacy_general_section'
+            );
+
+            add_settings_section(
+                'fp_privacy_categories_section',
+                __( 'Categorie di cookie', 'fp-privacy-cookie-policy' ),
+                '__return_false',
+                'fp_privacy_cookie_policy'
+            );
+
+            add_settings_field(
+                'cookie_categories',
+                __( 'Dettagli categorie', 'fp-privacy-cookie-policy' ),
+                array( $this, 'render_categories_fields' ),
+                'fp_privacy_cookie_policy',
+                'fp_privacy_categories_section'
+            );
+
+            add_settings_section(
+                'fp_privacy_google_section',
+                __( 'Google Consent Mode v2', 'fp-privacy-cookie-policy' ),
+                '__return_false',
+                'fp_privacy_cookie_policy'
+            );
+
+            add_settings_field(
+                'google_consent_defaults',
+                __( 'Stato di default', 'fp-privacy-cookie-policy' ),
+                array( $this, 'render_google_defaults' ),
+                'fp_privacy_cookie_policy',
+                'fp_privacy_google_section'
+            );
+        }
+
+        /**
+         * Sanitize settings.
+         *
+         * @param array $input Input values.
+         *
+         * @return array
+         */
+        public function sanitize_settings( $input ) {
+            $defaults = $this->get_default_settings();
+            $output   = wp_parse_args( $input, $defaults );
+
+            $output['privacy_policy_content'] = isset( $input['privacy_policy_content'] ) ? wp_kses_post( $input['privacy_policy_content'] ) : $defaults['privacy_policy_content'];
+            $output['cookie_policy_content']  = isset( $input['cookie_policy_content'] ) ? wp_kses_post( $input['cookie_policy_content'] ) : $defaults['cookie_policy_content'];
+
+            $banner_fields = array(
+                'banner_title'          => 'sanitize_text_field',
+                'accept_all_label'      => 'sanitize_text_field',
+                'reject_all_label'      => 'sanitize_text_field',
+                'preferences_label'     => 'sanitize_text_field',
+                'save_preferences_label'=> 'sanitize_text_field',
+            );
+
+            foreach ( $banner_fields as $field => $callback ) {
+                $output['banner'][ $field ] = isset( $input['banner'][ $field ] ) ? call_user_func( $callback, $input['banner'][ $field ] ) : $defaults['banner'][ $field ];
+            }
+
+            $output['banner']['banner_message'] = isset( $input['banner']['banner_message'] ) ? wp_kses_post( $input['banner']['banner_message'] ) : $defaults['banner']['banner_message'];
+
+            if ( isset( $input['banner']['show_reject'] ) ) {
+                $output['banner']['show_reject'] = (bool) $input['banner']['show_reject'];
+            } else {
+                $output['banner']['show_reject'] = false;
+            }
+
+            if ( isset( $input['banner']['show_preferences'] ) ) {
+                $output['banner']['show_preferences'] = (bool) $input['banner']['show_preferences'];
+            } else {
+                $output['banner']['show_preferences'] = false;
+            }
+
+            $categories = $defaults['categories'];
+
+            if ( isset( $input['categories'] ) && is_array( $input['categories'] ) ) {
+                foreach ( $categories as $key => $category ) {
+                    if ( isset( $input['categories'][ $key ]['enabled'] ) ) {
+                        $categories[ $key ]['enabled'] = (bool) $input['categories'][ $key ]['enabled'];
+                    } else {
+                        $categories[ $key ]['enabled'] = false;
+                    }
+
+                    if ( isset( $input['categories'][ $key ]['required'] ) ) {
+                        $categories[ $key ]['required'] = (bool) $input['categories'][ $key ]['required'];
+                    }
+
+                    if ( isset( $input['categories'][ $key ]['description'] ) ) {
+                        $categories[ $key ]['description'] = wp_kses_post( $input['categories'][ $key ]['description'] );
+                    }
+
+                    if ( isset( $input['categories'][ $key ]['services'] ) ) {
+                        $categories[ $key ]['services'] = sanitize_textarea_field( $input['categories'][ $key ]['services'] );
+                    }
+                }
+            }
+
+            $output['categories'] = $categories;
+
+            $google_defaults = $defaults['google_defaults'];
+
+            if ( isset( $input['google_defaults'] ) && is_array( $input['google_defaults'] ) ) {
+                foreach ( $google_defaults as $key => $value ) {
+                    $google_defaults[ $key ] = isset( $input['google_defaults'][ $key ] ) ? sanitize_text_field( $input['google_defaults'][ $key ] ) : $value;
+                }
+            }
+
+            $output['google_defaults'] = $google_defaults;
+
+            return $output;
+        }
+
+        /**
+         * Render privacy policy editor.
+         */
+        public function render_privacy_editor() {
+            $options = $this->get_settings();
+
+            wp_editor(
+                $options['privacy_policy_content'],
+                'fp_privacy_policy_content',
+                array(
+                    'textarea_name' => self::OPTION_KEY . '[privacy_policy_content]',
+                    'textarea_rows' => 10,
+                )
+            );
+        }
+
+        /**
+         * Render cookie policy editor.
+         */
+        public function render_cookie_editor() {
+            $options = $this->get_settings();
+
+            wp_editor(
+                $options['cookie_policy_content'],
+                'fp_cookie_policy_content',
+                array(
+                    'textarea_name' => self::OPTION_KEY . '[cookie_policy_content]',
+                    'textarea_rows' => 10,
+                )
+            );
+        }
+
+        /**
+         * Render banner settings.
+         */
+        public function render_banner_settings() {
+            $options = $this->get_settings();
+            $banner  = $options['banner'];
+            ?>
+            <fieldset class="fp-banner-settings">
+                <p>
+                    <label for="fp_banner_title"><strong><?php echo esc_html__( 'Titolo', 'fp-privacy-cookie-policy' ); ?></strong></label><br />
+                    <input type="text" class="regular-text" id="fp_banner_title" name="<?php echo esc_attr( self::OPTION_KEY ); ?>[banner][banner_title]" value="<?php echo esc_attr( $banner['banner_title'] ); ?>" />
+                </p>
+                <p>
+                    <label for="fp_banner_message"><strong><?php echo esc_html__( 'Messaggio', 'fp-privacy-cookie-policy' ); ?></strong></label><br />
+                    <textarea class="large-text" rows="4" id="fp_banner_message" name="<?php echo esc_attr( self::OPTION_KEY ); ?>[banner][banner_message]"><?php echo esc_textarea( $banner['banner_message'] ); ?></textarea>
+                </p>
+                <div class="fp-banner-grid">
+                    <p>
+                        <label for="fp_accept_all_label"><?php echo esc_html__( 'Etichetta "Accetta tutti"', 'fp-privacy-cookie-policy' ); ?></label><br />
+                        <input type="text" class="regular-text" id="fp_accept_all_label" name="<?php echo esc_attr( self::OPTION_KEY ); ?>[banner][accept_all_label]" value="<?php echo esc_attr( $banner['accept_all_label'] ); ?>" />
+                    </p>
+                    <p>
+                        <label for="fp_reject_all_label"><?php echo esc_html__( 'Etichetta "Rifiuta"', 'fp-privacy-cookie-policy' ); ?></label><br />
+                        <input type="text" class="regular-text" id="fp_reject_all_label" name="<?php echo esc_attr( self::OPTION_KEY ); ?>[banner][reject_all_label]" value="<?php echo esc_attr( $banner['reject_all_label'] ); ?>" />
+                    </p>
+                </div>
+                <div class="fp-banner-grid">
+                    <p>
+                        <label for="fp_preferences_label"><?php echo esc_html__( 'Etichetta "Preferenze"', 'fp-privacy-cookie-policy' ); ?></label><br />
+                        <input type="text" class="regular-text" id="fp_preferences_label" name="<?php echo esc_attr( self::OPTION_KEY ); ?>[banner][preferences_label]" value="<?php echo esc_attr( $banner['preferences_label'] ); ?>" />
+                    </p>
+                    <p>
+                        <label for="fp_save_preferences_label"><?php echo esc_html__( 'Etichetta "Salva"', 'fp-privacy-cookie-policy' ); ?></label><br />
+                        <input type="text" class="regular-text" id="fp_save_preferences_label" name="<?php echo esc_attr( self::OPTION_KEY ); ?>[banner][save_preferences_label]" value="<?php echo esc_attr( $banner['save_preferences_label'] ); ?>" />
+                    </p>
+                </div>
+                <p>
+                    <label>
+                        <input type="checkbox" name="<?php echo esc_attr( self::OPTION_KEY ); ?>[banner][show_reject]" value="1" <?php checked( $banner['show_reject'] ); ?> />
+                        <?php echo esc_html__( 'Mostra il pulsante "Rifiuta" nel banner principale', 'fp-privacy-cookie-policy' ); ?>
+                    </label>
+                </p>
+                <p>
+                    <label>
+                        <input type="checkbox" name="<?php echo esc_attr( self::OPTION_KEY ); ?>[banner][show_preferences]" value="1" <?php checked( $banner['show_preferences'] ); ?> />
+                        <?php echo esc_html__( 'Mostra il pulsante per aprire le preferenze direttamente nel banner', 'fp-privacy-cookie-policy' ); ?>
+                    </label>
+                </p>
+            </fieldset>
+            <?php
+        }
+
+        /**
+         * Render categories fields.
+         */
+        public function render_categories_fields() {
+            $options    = $this->get_settings();
+            $categories = $options['categories'];
+            ?>
+            <div class="fp-categories">
+                <?php foreach ( $categories as $key => $category ) : ?>
+                    <fieldset class="fp-category" id="fp_category_<?php echo esc_attr( $key ); ?>">
+                        <legend><strong><?php echo esc_html( $category['label'] ); ?></strong></legend>
+                        <p>
+                            <label>
+                                <input type="checkbox" name="<?php echo esc_attr( self::OPTION_KEY ); ?>[categories][<?php echo esc_attr( $key ); ?>][enabled]" value="1" <?php checked( $category['enabled'] ); ?> <?php disabled( $category['required'] ); ?> />
+                                <?php echo esc_html__( 'Mostra categoria nelle preferenze', 'fp-privacy-cookie-policy' ); ?>
+                            </label>
+                        </p>
+                        <p>
+                            <label>
+                                <input type="checkbox" name="<?php echo esc_attr( self::OPTION_KEY ); ?>[categories][<?php echo esc_attr( $key ); ?>][required]" value="1" <?php checked( $category['required'] ); ?> <?php disabled( $category['required'] ); ?> />
+                                <?php echo esc_html__( 'Necessario (non disattivabile)', 'fp-privacy-cookie-policy' ); ?>
+                            </label>
+                        </p>
+                        <p>
+                            <label for="fp_category_<?php echo esc_attr( $key ); ?>_description"><?php echo esc_html__( 'Descrizione', 'fp-privacy-cookie-policy' ); ?></label><br />
+                            <textarea class="large-text" rows="3" id="fp_category_<?php echo esc_attr( $key ); ?>_description" name="<?php echo esc_attr( self::OPTION_KEY ); ?>[categories][<?php echo esc_attr( $key ); ?>][description]"><?php echo esc_textarea( $category['description'] ); ?></textarea>
+                        </p>
+                        <p>
+                            <label for="fp_category_<?php echo esc_attr( $key ); ?>_services"><?php echo esc_html__( 'Servizi e cookie inclusi', 'fp-privacy-cookie-policy' ); ?></label><br />
+                            <textarea class="large-text" rows="3" id="fp_category_<?php echo esc_attr( $key ); ?>_services" name="<?php echo esc_attr( self::OPTION_KEY ); ?>[categories][<?php echo esc_attr( $key ); ?>][services]"><?php echo esc_textarea( $category['services'] ); ?></textarea>
+                            <span class="description"><?php echo esc_html__( 'Indica ad esempio strumenti di analytics, pixel e durata dei cookie per agevolare la documentazione.', 'fp-privacy-cookie-policy' ); ?></span>
+                        </p>
+                    </fieldset>
+                <?php endforeach; ?>
+            </div>
+            <?php
+        }
+
+        /**
+         * Render Google consent defaults.
+         */
+        public function render_google_defaults() {
+            $options         = $this->get_settings();
+            $google_defaults = $options['google_defaults'];
+            ?>
+            <table class="widefat striped">
+                <thead>
+                    <tr>
+                        <th><?php echo esc_html__( 'Segnale', 'fp-privacy-cookie-policy' ); ?></th>
+                        <th><?php echo esc_html__( 'Valore di default', 'fp-privacy-cookie-policy' ); ?></th>
+                        <th><?php echo esc_html__( 'Descrizione', 'fp-privacy-cookie-policy' ); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ( $google_defaults as $signal => $value ) : ?>
+                        <tr>
+                            <td><code><?php echo esc_html( $signal ); ?></code></td>
+                            <td>
+                                <select name="<?php echo esc_attr( self::OPTION_KEY ); ?>[google_defaults][<?php echo esc_attr( $signal ); ?>]">
+                                    <option value="granted" <?php selected( 'granted', $value ); ?>><?php echo esc_html__( 'Granted', 'fp-privacy-cookie-policy' ); ?></option>
+                                    <option value="denied" <?php selected( 'denied', $value ); ?>><?php echo esc_html__( 'Denied', 'fp-privacy-cookie-policy' ); ?></option>
+                                </select>
+                            </td>
+                            <td><?php echo esc_html( $this->describe_google_signal( $signal ) ); ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+            <?php
+        }
+
+        /**
+         * Describe Google signal.
+         *
+         * @param string $signal Signal.
+         *
+         * @return string
+         */
+        protected function describe_google_signal( $signal ) {
+            $descriptions = array(
+                'analytics_storage'   => __( 'Abilita la memorizzazione dei cookie per Google Analytics e servizi di misurazione.', 'fp-privacy-cookie-policy' ),
+                'ad_storage'          => __( 'Abilita i cookie pubblicitari e il retargeting (ad esempio Google Ads).', 'fp-privacy-cookie-policy' ),
+                'ad_user_data'        => __( 'Permette di inviare dati utente a Google per finalità pubblicitarie.', 'fp-privacy-cookie-policy' ),
+                'ad_personalization'  => __( 'Consente la personalizzazione degli annunci in base al comportamento.', 'fp-privacy-cookie-policy' ),
+                'functionality_storage' => __( 'Cookie per ricordare preferenze, lingua e altre funzionalità.', 'fp-privacy-cookie-policy' ),
+                'security_storage'    => __( 'Cookie destinati alla prevenzione delle frodi e alla sicurezza.', 'fp-privacy-cookie-policy' ),
+            );
+
+            return isset( $descriptions[ $signal ] ) ? $descriptions[ $signal ] : '';
+        }
+
+        /**
+         * Get plugin settings.
+         *
+         * @return array
+         */
+        public function get_settings() {
+            $defaults = $this->get_default_settings();
+            $options  = get_option( self::OPTION_KEY, array() );
+
+            return wp_parse_args( $options, $defaults );
+        }
+
+        /**
+         * Plugin default settings.
+         *
+         * @return array
+         */
+        public function get_default_settings() {
+            return array(
+                'privacy_policy_content' => __( '<h2>Informativa Privacy</h2><p>Inserisci qui il testo della tua informativa privacy conforme al GDPR, includendo i diritti dell\'interessato, i dati di contatto del titolare e le finalità del trattamento.</p>', 'fp-privacy-cookie-policy' ),
+                'cookie_policy_content'  => __( '<h2>Informativa Cookie</h2><p>Descrivi i cookie utilizzati dal sito, le finalità e la base giuridica del trattamento. Ricorda di aggiornare periodicamente questo elenco.</p>', 'fp-privacy-cookie-policy' ),
+                'banner'                 => array(
+                    'banner_title'          => __( 'Rispettiamo la tua privacy', 'fp-privacy-cookie-policy' ),
+                    'banner_message'        => __( 'Utilizziamo cookie tecnici e, previo consenso, cookie di profilazione e di terze parti per migliorare l\'esperienza di navigazione. Puoi gestire le tue preferenze in qualsiasi momento.', 'fp-privacy-cookie-policy' ),
+                    'accept_all_label'      => __( 'Accetta tutto', 'fp-privacy-cookie-policy' ),
+                    'reject_all_label'      => __( 'Rifiuta', 'fp-privacy-cookie-policy' ),
+                    'preferences_label'     => __( 'Preferenze', 'fp-privacy-cookie-policy' ),
+                    'save_preferences_label'=> __( 'Salva preferenze', 'fp-privacy-cookie-policy' ),
+                    'show_reject'           => true,
+                    'show_preferences'      => true,
+                ),
+                'categories'             => array(
+                    'necessary'     => array(
+                        'label'       => __( 'Necessari', 'fp-privacy-cookie-policy' ),
+                        'description' => __( 'Cookie indispensabili per il funzionamento del sito e la fornitura del servizio.', 'fp-privacy-cookie-policy' ),
+                        'services'    => __( "WordPress (sessione), cookie di autenticazione, salvataggio preferenze.", 'fp-privacy-cookie-policy' ),
+                        'required'    => true,
+                        'enabled'     => true,
+                    ),
+                    'preferences'   => array(
+                        'label'       => __( 'Preferenze', 'fp-privacy-cookie-policy' ),
+                        'description' => __( 'Consentono al sito di ricordare le scelte effettuate dall\'utente, come la lingua o la regione.', 'fp-privacy-cookie-policy' ),
+                        'services'    => '',
+                        'required'    => false,
+                        'enabled'     => true,
+                    ),
+                    'statistics'    => array(
+                        'label'       => __( 'Statistiche', 'fp-privacy-cookie-policy' ),
+                        'description' => __( 'Aiutano a capire come i visitatori interagiscono con il sito raccogliendo e trasmettendo informazioni in forma anonima.', 'fp-privacy-cookie-policy' ),
+                        'services'    => __( 'Google Analytics 4 (2 anni), Matomo (13 mesi).', 'fp-privacy-cookie-policy' ),
+                        'required'    => false,
+                        'enabled'     => true,
+                    ),
+                    'marketing'     => array(
+                        'label'       => __( 'Marketing', 'fp-privacy-cookie-policy' ),
+                        'description' => __( 'Vengono utilizzati per tracciare i visitatori e proporre annunci personalizzati.', 'fp-privacy-cookie-policy' ),
+                        'services'    => __( 'Google Ads, Meta Pixel, TikTok Pixel.', 'fp-privacy-cookie-policy' ),
+                        'required'    => false,
+                        'enabled'     => true,
+                    ),
+                ),
+                'google_defaults'        => array(
+                    'analytics_storage'    => 'denied',
+                    'ad_storage'           => 'denied',
+                    'ad_user_data'         => 'denied',
+                    'ad_personalization'   => 'denied',
+                    'functionality_storage'=> 'granted',
+                    'security_storage'     => 'granted',
+                ),
+            );
+        }
+
+        /**
+         * Enqueue admin assets.
+         */
+        public function enqueue_admin_assets( $hook ) {
+            if ( 'toplevel_page_fp-privacy-cookie-policy' !== $hook ) {
+                return;
+            }
+
+            wp_enqueue_style( 'fp-privacy-admin', plugin_dir_url( __FILE__ ) . 'assets/css/admin.css', array(), self::VERSION );
+        }
+
+        /**
+         * Enqueue frontend assets.
+         */
+        public function enqueue_frontend_assets() {
+            $options = $this->get_settings();
+
+            wp_enqueue_style( 'fp-privacy-frontend', plugin_dir_url( __FILE__ ) . 'assets/css/banner.css', array(), self::VERSION );
+
+            wp_register_script( 'fp-privacy-frontend', plugin_dir_url( __FILE__ ) . 'assets/js/fp-consent.js', array(), self::VERSION, true );
+
+            $localize = array(
+                'ajaxUrl'        => admin_url( 'admin-ajax.php' ),
+                'nonce'          => wp_create_nonce( self::NONCE_ACTION ),
+                'cookieName'     => self::CONSENT_COOKIE,
+                'consentId'      => $this->get_consent_id(),
+                'categories'     => $this->prepare_categories_for_frontend( $options['categories'] ),
+                'banner'         => $options['banner'],
+                'googleDefaults' => $options['google_defaults'],
+                'texts'          => array(
+                    'manageConsent' => __( 'Gestisci preferenze cookie', 'fp-privacy-cookie-policy' ),
+                    'updatedAt'     => __( 'Ultimo aggiornamento', 'fp-privacy-cookie-policy' ),
+                ),
+            );
+
+            wp_localize_script( 'fp-privacy-frontend', 'fpPrivacySettings', $localize );
+            wp_enqueue_script( 'fp-privacy-frontend' );
+        }
+
+        /**
+         * Prepare categories for frontend.
+         *
+         * @param array $categories Categories.
+         *
+         * @return array
+         */
+        protected function prepare_categories_for_frontend( $categories ) {
+            $prepared = array();
+
+            foreach ( $categories as $key => $category ) {
+                $prepared[ $key ] = array(
+                    'label'       => $category['label'],
+                    'description' => wp_kses_post( $category['description'] ),
+                    'services'    => $category['services'],
+                    'required'    => (bool) $category['required'],
+                    'enabled'     => (bool) $category['enabled'],
+                );
+            }
+
+            return $prepared;
+        }
+
+        /**
+         * Render consent banner markup.
+         */
+        public function render_consent_banner() {
+            $options = $this->get_settings();
+
+            $banner        = $options['banner'];
+            $categories    = $options['categories'];
+            $has_preferred = ! empty( array_filter( $categories, static function ( $category ) {
+                return ! empty( $category['enabled'] ) && empty( $category['required'] );
+            } ) );
+            ?>
+            <div class="fp-consent-banner" role="dialog" aria-live="polite" aria-modal="true" data-cookie-name="<?php echo esc_attr( self::CONSENT_COOKIE ); ?>">
+                <div class="fp-consent-container">
+                    <div class="fp-consent-content">
+                        <h3 class="fp-consent-title"><?php echo esc_html( $banner['banner_title'] ); ?></h3>
+                        <div class="fp-consent-text"><?php echo wpautop( wp_kses_post( $banner['banner_message'] ) ); ?></div>
+                    </div>
+                    <div class="fp-consent-actions">
+                        <button class="fp-btn fp-btn-primary" data-consent-action="accept-all"><?php echo esc_html( $banner['accept_all_label'] ); ?></button>
+                        <?php if ( $banner['show_reject'] ) : ?>
+                            <button class="fp-btn fp-btn-secondary" data-consent-action="reject-all"><?php echo esc_html( $banner['reject_all_label'] ); ?></button>
+                        <?php endif; ?>
+                        <?php if ( $banner['show_preferences'] && $has_preferred ) : ?>
+                            <button class="fp-btn fp-btn-tertiary" data-consent-action="open-preferences"><?php echo esc_html( $banner['preferences_label'] ); ?></button>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+            <div class="fp-consent-modal" role="dialog" aria-modal="true" aria-labelledby="fp-consent-modal-title" hidden>
+                <div class="fp-consent-modal__overlay" data-consent-action="close"></div>
+                <div class="fp-consent-modal__dialog" role="document">
+                    <button class="fp-consent-modal__close" type="button" aria-label="<?php echo esc_attr__( 'Chiudi', 'fp-privacy-cookie-policy' ); ?>" data-consent-action="close">&times;</button>
+                    <h3 id="fp-consent-modal-title"><?php echo esc_html__( 'Gestisci le preferenze', 'fp-privacy-cookie-policy' ); ?></h3>
+                    <p class="fp-consent-modal__intro"><?php esc_html_e( 'Decidi quali categorie di cookie attivare. Puoi modificare la tua scelta in qualsiasi momento.', 'fp-privacy-cookie-policy' ); ?></p>
+                    <div class="fp-consent-categories">
+                        <?php foreach ( $categories as $key => $category ) : ?>
+                            <?php if ( empty( $category['enabled'] ) && empty( $category['required'] ) ) : ?>
+                                <?php continue; ?>
+                            <?php endif; ?>
+                            <div class="fp-consent-category" data-category-key="<?php echo esc_attr( $key ); ?>">
+                                <div class="fp-consent-category__header">
+                                    <div>
+                                        <h4><?php echo esc_html( $category['label'] ); ?></h4>
+                                        <p><?php echo esc_html( wp_strip_all_tags( $category['description'] ) ); ?></p>
+                                        <?php if ( ! empty( $category['services'] ) ) : ?>
+                                            <details>
+                                                <summary><?php esc_html_e( 'Servizi inclusi', 'fp-privacy-cookie-policy' ); ?></summary>
+                                                <p><?php echo esc_html( $category['services'] ); ?></p>
+                                            </details>
+                                        <?php endif; ?>
+                                    </div>
+                                    <div class="fp-consent-toggle">
+                                        <?php if ( ! empty( $category['required'] ) ) : ?>
+                                            <span class="fp-consent-required"><?php esc_html_e( 'Sempre attivo', 'fp-privacy-cookie-policy' ); ?></span>
+                                        <?php else : ?>
+                                            <label class="fp-switch">
+                                                <input type="checkbox" value="1" data-category-toggle="<?php echo esc_attr( $key ); ?>" />
+                                                <span class="fp-slider" aria-hidden="true"></span>
+                                                <span class="screen-reader-text"><?php echo esc_html( sprintf( __( 'Attiva o disattiva i cookie %s', 'fp-privacy-cookie-policy' ), $category['label'] ) ); ?></span>
+                                            </label>
+                                        <?php endif; ?>
+                                    </div>
+                                </div>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                    <div class="fp-consent-modal__actions">
+                        <button class="fp-btn fp-btn-primary" data-consent-action="save-preferences"><?php echo esc_html( $banner['save_preferences_label'] ); ?></button>
+                        <?php if ( $banner['show_reject'] ) : ?>
+                            <button class="fp-btn fp-btn-secondary" data-consent-action="reject-all"><?php echo esc_html( $banner['reject_all_label'] ); ?></button>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+            <?php
+        }
+
+        /**
+         * Register shortcodes.
+         */
+        public function register_shortcodes() {
+            add_shortcode( 'fp_privacy_policy', array( $this, 'shortcode_privacy_policy' ) );
+            add_shortcode( 'fp_cookie_policy', array( $this, 'shortcode_cookie_policy' ) );
+            add_shortcode( 'fp_cookie_preferences', array( $this, 'shortcode_cookie_preferences' ) );
+        }
+
+        /**
+         * Privacy policy shortcode callback.
+         *
+         * @return string
+         */
+        public function shortcode_privacy_policy() {
+            $options = $this->get_settings();
+
+            return '<div class="fp-privacy-policy">' . wp_kses_post( $options['privacy_policy_content'] ) . '</div>';
+        }
+
+        /**
+         * Cookie policy shortcode callback.
+         *
+         * @return string
+         */
+        public function shortcode_cookie_policy() {
+            $options = $this->get_settings();
+
+            return '<div class="fp-cookie-policy">' . wp_kses_post( $options['cookie_policy_content'] ) . '</div>';
+        }
+
+        /**
+         * Cookie preferences shortcode callback.
+         *
+         * @return string
+         */
+        public function shortcode_cookie_preferences() {
+            $options = $this->get_settings();
+            $banner  = $options['banner'];
+
+            return '<button class="fp-btn fp-btn-preferences" data-consent-action="open-preferences">' . esc_html( $banner['preferences_label'] ) . '</button>';
+        }
+
+        /**
+         * Render settings page.
+         */
+        public function render_settings_page() {
+            if ( ! current_user_can( 'manage_options' ) ) {
+                return;
+            }
+
+            $active_tab = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : 'settings';
+            ?>
+            <div class="wrap fp-privacy-admin">
+                <h1><?php esc_html_e( 'Privacy e Cookie Policy', 'fp-privacy-cookie-policy' ); ?></h1>
+                <h2 class="nav-tab-wrapper">
+                    <a href="<?php echo esc_url( admin_url( 'admin.php?page=fp-privacy-cookie-policy&tab=settings' ) ); ?>" class="nav-tab <?php echo 'settings' === $active_tab ? 'nav-tab-active' : ''; ?>"><?php esc_html_e( 'Impostazioni', 'fp-privacy-cookie-policy' ); ?></a>
+                    <a href="<?php echo esc_url( admin_url( 'admin.php?page=fp-privacy-cookie-policy&tab=logs' ) ); ?>" class="nav-tab <?php echo 'logs' === $active_tab ? 'nav-tab-active' : ''; ?>"><?php esc_html_e( 'Registro consensi', 'fp-privacy-cookie-policy' ); ?></a>
+                    <a href="<?php echo esc_url( admin_url( 'admin.php?page=fp-privacy-cookie-policy&tab=help' ) ); ?>" class="nav-tab <?php echo 'help' === $active_tab ? 'nav-tab-active' : ''; ?>"><?php esc_html_e( 'Guida rapida', 'fp-privacy-cookie-policy' ); ?></a>
+                </h2>
+
+                <?php if ( 'logs' === $active_tab ) : ?>
+                    <?php $this->render_logs_tab(); ?>
+                <?php elseif ( 'help' === $active_tab ) : ?>
+                    <?php $this->render_help_tab(); ?>
+                <?php else : ?>
+                    <form method="post" action="options.php">
+                        <?php
+                        settings_fields( 'fp_privacy_cookie_group' );
+                        do_settings_sections( 'fp_privacy_cookie_policy' );
+                        submit_button();
+                        ?>
+                    </form>
+                <?php endif; ?>
+            </div>
+            <?php
+        }
+
+        /**
+         * Render logs tab.
+         */
+        protected function render_logs_tab() {
+            global $wpdb;
+
+            $table_name = $wpdb->prefix . self::CONSENT_TABLE;
+            $per_page   = 50;
+            $paged      = isset( $_GET['paged'] ) ? max( 1, (int) $_GET['paged'] ) : 1;
+            $offset     = ( $paged - 1 ) * $per_page;
+
+            $logs = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT * FROM {$table_name} ORDER BY created_at DESC LIMIT %d OFFSET %d",
+                    $per_page,
+                    $offset
+                )
+            );
+
+            $total = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table_name}" );
+            $pages = (int) ceil( $total / $per_page );
+            ?>
+            <div class="fp-consent-log-actions">
+                <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                    <?php wp_nonce_field( 'fp_export_consent', 'fp_export_consent_nonce' ); ?>
+                    <input type="hidden" name="action" value="fp_export_consent" />
+                    <button type="submit" class="button button-secondary">
+                        <?php esc_html_e( 'Esporta CSV', 'fp-privacy-cookie-policy' ); ?>
+                    </button>
+                </form>
+            </div>
+            <table class="widefat striped fp-consent-log-table">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e( 'Data', 'fp-privacy-cookie-policy' ); ?></th>
+                        <th><?php esc_html_e( 'ID consenso', 'fp-privacy-cookie-policy' ); ?></th>
+                        <th><?php esc_html_e( 'Utente', 'fp-privacy-cookie-policy' ); ?></th>
+                        <th><?php esc_html_e( 'Evento', 'fp-privacy-cookie-policy' ); ?></th>
+                        <th><?php esc_html_e( 'Stato', 'fp-privacy-cookie-policy' ); ?></th>
+                        <th><?php esc_html_e( 'IP', 'fp-privacy-cookie-policy' ); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if ( $logs ) : ?>
+                        <?php foreach ( $logs as $log ) : ?>
+                            <tr>
+                                <td><?php echo esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $log->created_at ) ) ); ?></td>
+                                <td><code><?php echo esc_html( $log->consent_id ); ?></code></td>
+                                <td>
+                                    <?php
+                                    $user_label = __( 'Anonimo', 'fp-privacy-cookie-policy' );
+
+                                    if ( $log->user_id ) {
+                                        $user = get_userdata( (int) $log->user_id );
+                                        if ( $user ) {
+                                            $user_label = $user->user_login;
+                                        }
+                                    }
+
+                                    echo esc_html( $user_label );
+                                    ?>
+                                </td>
+                                <td><?php echo esc_html( $log->event_type ); ?></td>
+                                <td><code><?php echo esc_html( $log->consent_state ); ?></code></td>
+                                <td><?php echo esc_html( $log->ip_address ); ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php else : ?>
+                        <tr>
+                            <td colspan="6"><?php esc_html_e( 'Nessun consenso registrato al momento.', 'fp-privacy-cookie-policy' ); ?></td>
+                        </tr>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+            <?php if ( $pages > 1 ) : ?>
+                <div class="tablenav">
+                    <div class="tablenav-pages">
+                        <?php
+                        echo wp_kses_post(
+                            paginate_links(
+                                array(
+                                    'base'      => add_query_arg( array( 'paged' => '%#%', 'tab' => 'logs' ) ),
+                                    'format'    => '',
+                                    'prev_text' => __( '&laquo;', 'fp-privacy-cookie-policy' ),
+                                    'next_text' => __( '&raquo;', 'fp-privacy-cookie-policy' ),
+                                    'total'     => $pages,
+                                    'current'   => $paged,
+                                )
+                            )
+                        );
+                        ?>
+                    </div>
+                </div>
+            <?php endif; ?>
+            <?php
+        }
+
+        /**
+         * Render help tab.
+         */
+        protected function render_help_tab() {
+            $options = $this->get_settings();
+            ?>
+            <div class="fp-help-tab">
+                <h2><?php esc_html_e( 'Checklist di conformità', 'fp-privacy-cookie-policy' ); ?></h2>
+                <ol>
+                    <li><?php esc_html_e( 'Aggiorna i testi di privacy e cookie policy con il supporto del tuo consulente legale.', 'fp-privacy-cookie-policy' ); ?></li>
+                    <li><?php esc_html_e( 'Configura le categorie e collega i servizi realmente utilizzati sul sito.', 'fp-privacy-cookie-policy' ); ?></li>
+                    <li><?php esc_html_e( 'Imposta i valori predefiniti del Google Consent Mode in base al principio di minimizzazione.', 'fp-privacy-cookie-policy' ); ?></li>
+                    <li><?php esc_html_e( 'Inserisci nei template il codice di Google tag manager/gtag.js condizionato dagli eventi di consenso.', 'fp-privacy-cookie-policy' ); ?></li>
+                    <li><?php esc_html_e( 'Conserva il registro dei consensi per almeno 12 mesi o secondo le policy del cliente.', 'fp-privacy-cookie-policy' ); ?></li>
+                </ol>
+                <h3><?php esc_html_e( 'Shortcode disponibili', 'fp-privacy-cookie-policy' ); ?></h3>
+                <ul>
+                    <li><code>[fp_privacy_policy]</code> &mdash; <?php esc_html_e( 'Mostra il testo della privacy policy configurato.', 'fp-privacy-cookie-policy' ); ?></li>
+                    <li><code>[fp_cookie_policy]</code> &mdash; <?php esc_html_e( 'Mostra il testo della cookie policy.', 'fp-privacy-cookie-policy' ); ?></li>
+                    <li><code>[fp_cookie_preferences]</code> &mdash; <?php esc_html_e( 'Inserisce un pulsante per riaprire le preferenze di consenso.', 'fp-privacy-cookie-policy' ); ?></li>
+                </ul>
+                <h3><?php esc_html_e( 'Come collegare Google Consent Mode v2', 'fp-privacy-cookie-policy' ); ?></h3>
+                <p><?php esc_html_e( 'Questo plugin aggiorna automaticamente i segnali del Consent Mode (analytics_storage, ad_storage, ad_personalization, ad_user_data, functionality_storage, security_storage). Assicurati che il tag gtag o Google Tag Manager sia caricato dopo il banner e che ascolti l\'evento fp_consent_update se utilizzi configurazioni personalizzate.', 'fp-privacy-cookie-policy' ); ?></p>
+                <p>
+                    <code>
+                        &lt;script&gt;
+                        window.dataLayer = window.dataLayer || [];
+                        function gtag(){dataLayer.push(arguments);}
+                        gtag('js', new Date());
+                        gtag('config', 'G-XXXXXXX');
+                        &lt;/script&gt;
+                    </code>
+                </p>
+                <p><?php esc_html_e( 'Ricorda di richiedere nuovamente il consenso ogni 12 mesi o quando cambiano le finalità del trattamento.', 'fp-privacy-cookie-policy' ); ?></p>
+                <p>
+                    <?php
+                    printf(
+                        /* translators: %s is the shortcode */
+                        esc_html__( 'Ultimo aggiornamento contenuti: %s', 'fp-privacy-cookie-policy' ),
+                        '<strong>' . esc_html( date_i18n( get_option( 'date_format' ) ) ) . '</strong>'
+                    );
+                    ?>
+                </p>
+            </div>
+            <?php
+        }
+
+        /**
+         * Handle consent saving via AJAX.
+         */
+        public function ajax_save_consent() {
+            check_ajax_referer( self::NONCE_ACTION, 'nonce' );
+
+            $consent_id = isset( $_POST['consentId'] ) ? sanitize_text_field( wp_unslash( $_POST['consentId'] ) ) : '';
+            $event      = isset( $_POST['event'] ) ? sanitize_key( wp_unslash( $_POST['event'] ) ) : 'save';
+            $consent    = isset( $_POST['consent'] ) ? wp_unslash( $_POST['consent'] ) : array();
+
+            if ( empty( $consent_id ) || empty( $consent ) || ! is_array( $consent ) ) {
+                wp_send_json_error( array( 'message' => __( 'Dati non validi.', 'fp-privacy-cookie-policy' ) ), 400 );
+            }
+
+            $sanitized = array();
+
+            foreach ( $consent as $key => $value ) {
+                $sanitized[ sanitize_key( $key ) ] = rest_sanitize_boolean( $value );
+            }
+
+            $this->log_consent( $consent_id, $event, $sanitized );
+
+            wp_send_json_success( array( 'message' => __( 'Consenso aggiornato.', 'fp-privacy-cookie-policy' ) ) );
+        }
+
+        /**
+         * Log consent event.
+         *
+         * @param string $consent_id Consent ID.
+         * @param string $event      Event type.
+         * @param array  $consent    Consent data.
+         */
+        protected function log_consent( $consent_id, $event, $consent ) {
+            global $wpdb;
+
+            $table_name = $wpdb->prefix . self::CONSENT_TABLE;
+
+            $ip_address = isset( $_SERVER['REMOTE_ADDR'] ) ? wp_unslash( $_SERVER['REMOTE_ADDR'] ) : '';
+            $ip_address = wp_privacy_anonymize_ip( $ip_address );
+            $user_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
+            $user_id    = get_current_user_id();
+
+            $wpdb->insert(
+                $table_name,
+                array(
+                    'consent_id'    => $consent_id,
+                    'user_id'       => $user_id ? $user_id : null,
+                    'event_type'    => $event,
+                    'consent_state' => wp_json_encode( $consent ),
+                    'ip_address'    => $ip_address,
+                    'user_agent'    => $user_agent,
+                    'created_at'    => current_time( 'mysql' ),
+                ),
+                array( '%s', '%d', '%s', '%s', '%s', '%s', '%s' )
+            );
+        }
+
+        /**
+         * Export consent logs as CSV.
+         */
+        public function export_consent_logs() {
+            if ( ! current_user_can( 'manage_options' ) ) {
+                wp_die( esc_html__( 'Non autorizzato.', 'fp-privacy-cookie-policy' ) );
+            }
+
+            check_admin_referer( 'fp_export_consent', 'fp_export_consent_nonce' );
+
+            global $wpdb;
+
+            $table_name = $wpdb->prefix . self::CONSENT_TABLE;
+
+            $logs = $wpdb->get_results( "SELECT * FROM {$table_name} ORDER BY created_at DESC" );
+
+            nocache_headers();
+            header( 'Content-Type: text/csv; charset=utf-8' );
+            header( 'Content-Disposition: attachment; filename=fp-consent-logs-' . gmdate( 'Ymd-His' ) . '.csv' );
+
+            $output = fopen( 'php://output', 'w' );
+
+            fputcsv( $output, array( 'created_at', 'consent_id', 'user_id', 'event_type', 'consent_state', 'ip_address', 'user_agent' ) );
+
+            foreach ( $logs as $log ) {
+                fputcsv( $output, array( $log->created_at, $log->consent_id, $log->user_id, $log->event_type, $log->consent_state, $log->ip_address, $log->user_agent ) );
+            }
+
+            fclose( $output );
+
+            exit;
+        }
+
+        /**
+         * Generate or retrieve consent ID.
+         *
+         * @return string
+         */
+        protected function get_consent_id() {
+            if ( isset( $_COOKIE[ self::CONSENT_COOKIE . '_id' ] ) ) {
+                return sanitize_text_field( wp_unslash( $_COOKIE[ self::CONSENT_COOKIE . '_id' ] ) );
+            }
+
+            $consent_id = wp_generate_uuid4();
+
+            $path   = defined( 'COOKIEPATH' ) ? COOKIEPATH : '/';
+            $domain = defined( 'COOKIE_DOMAIN' ) ? COOKIE_DOMAIN : '';
+
+            setcookie( self::CONSENT_COOKIE . '_id', $consent_id, time() + YEAR_IN_SECONDS, $path, $domain, is_ssl(), true );
+
+            return $consent_id;
+        }
+    }
+
+    register_activation_hook( __FILE__, array( 'FP_Privacy_Cookie_Policy', 'activate' ) );
+    register_deactivation_hook( __FILE__, array( 'FP_Privacy_Cookie_Policy', 'deactivate' ) );
+    register_uninstall_hook( __FILE__, array( 'FP_Privacy_Cookie_Policy', 'uninstall' ) );
+
+    FP_Privacy_Cookie_Policy::instance();
+}


### PR DESCRIPTION
## Summary
- add a WordPress plugin that manages privacy and cookie policies with configurable banner, shortcode support, consent registry and Google Consent Mode v2 integration
- implement frontend assets to display and manage the consent banner, push Consent Mode signals and log user decisions
- document installation, configuration and compliance guidance for Italian GDPR requirements

## Testing
- php -l fp-privacy-cookie-policy/fp-privacy-cookie-policy.php

------
https://chatgpt.com/codex/tasks/task_e_68d3dfd09324832f808844f15dc2e6ac