### PR TITLE
Add configurable consent cookie duration

### DIFF
--- a/fp-privacy-cookie-policy/assets/js/fp-consent.js
+++ b/fp-privacy-cookie-policy/assets/js/fp-consent.js
@@ -10,6 +10,10 @@
     var consentId = settings.consentId || '';
     var categories = settings.categories || {};
     var googleDefaults = settings.googleDefaults || {};
+    var cookieTtlDays = parseInt(settings.cookieTtlDays, 10);
+    if (isNaN(cookieTtlDays)) {
+        cookieTtlDays = null;
+    }
     var requiredKeys = Object.keys(categories).filter(function (key) {
         return categories[key] && categories[key].required;
     });
@@ -262,7 +266,24 @@
 
     function storeConsentCookie(state) {
         var value = encodeURIComponent(JSON.stringify(state));
-        var attributes = ['path=/','max-age=' + 60 * 60 * 24 * 365,'SameSite=Lax'];
+        var attributes = ['path=/', 'SameSite=Lax'];
+        var maxAgeSeconds = null;
+
+        if (cookieTtlDays === 0) {
+            maxAgeSeconds = null;
+        } else if (cookieTtlDays && cookieTtlDays > 0) {
+            maxAgeSeconds = cookieTtlDays * 24 * 60 * 60;
+        } else {
+            maxAgeSeconds = 365 * 24 * 60 * 60;
+        }
+
+        if (maxAgeSeconds) {
+            attributes.push('max-age=' + maxAgeSeconds);
+            var expires = new Date();
+            expires.setTime(expires.getTime() + maxAgeSeconds * 1000);
+            attributes.push('expires=' + expires.toUTCString());
+        }
+
         if (window.location && window.location.protocol === 'https:') {
             attributes.push('Secure');
         }

--- a/fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
+++ b/fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
@@ -3,7 +3,7 @@
  * Plugin Name: FP Privacy and Cookie Policy
  * Plugin URI:  https://example.com/
  * Description: Gestisci privacy policy, cookie policy e consenso informato in modo conforme al GDPR e al Google Consent Mode v2.
- * Version:     1.2.0
+ * Version:     1.3.0
  * Author:      FP Digital Assistant
  * Author URI:  https://example.com/
  * License:     GPL2
@@ -24,7 +24,7 @@ if ( ! class_exists( 'FP_Privacy_Cookie_Policy' ) ) {
     class FP_Privacy_Cookie_Policy {
 
         const OPTION_KEY        = 'fp_privacy_cookie_settings';
-        const VERSION           = '1.2.0';
+        const VERSION           = '1.3.0';
         const VERSION_OPTION    = 'fp_privacy_cookie_version';
         const CONSENT_COOKIE    = 'fp_consent_state';
         const CONSENT_TABLE     = 'fp_consent_logs';
@@ -606,6 +606,14 @@ if ( ! class_exists( 'FP_Privacy_Cookie_Policy' ) ) {
                 'fp_privacy_general_section'
             );
 
+            add_settings_field(
+                'consent_cookie_days',
+                __( 'Durata cookie di consenso', 'fp-privacy-cookie-policy' ),
+                array( $this, 'render_consent_cookie_field' ),
+                'fp_privacy_cookie_policy',
+                'fp_privacy_general_section'
+            );
+
             add_settings_section(
                 'fp_privacy_categories_section',
                 __( 'Categorie di cookie', 'fp-privacy-cookie-policy' ),
@@ -663,6 +671,10 @@ if ( ! class_exists( 'FP_Privacy_Cookie_Policy' ) ) {
             $output['retention_days']  = $this->sanitize_retention_days(
                 isset( $input['retention_days'] ) ? $input['retention_days'] : $defaults['retention_days'],
                 $defaults['retention_days']
+            );
+            $output['consent_cookie_days'] = $this->sanitize_cookie_duration_days(
+                isset( $input['consent_cookie_days'] ) ? $input['consent_cookie_days'] : $defaults['consent_cookie_days'],
+                $defaults['consent_cookie_days']
             );
 
             return $output;
@@ -958,6 +970,46 @@ if ( ! class_exists( 'FP_Privacy_Cookie_Policy' ) ) {
         }
 
         /**
+         * Sanitize consent cookie duration value.
+         *
+         * @param mixed $value   Incoming value.
+         * @param int   $default Default duration.
+         *
+         * @return int
+         */
+        protected function sanitize_cookie_duration_days( $value, $default ) {
+            if ( '' === $value ) {
+                return (int) $default;
+            }
+
+            if ( is_string( $value ) ) {
+                $value = trim( $value );
+            }
+
+            if ( ! is_numeric( $value ) ) {
+                return (int) $default;
+            }
+
+            $value = (int) $value;
+
+            if ( $value < 0 ) {
+                return (int) $default;
+            }
+
+            if ( 0 === $value ) {
+                return 0;
+            }
+
+            $minimum = (int) apply_filters( 'fp_privacy_consent_cookie_min_days', 30 );
+
+            if ( $minimum < 1 ) {
+                $minimum = 1;
+            }
+
+            return max( $minimum, $value );
+        }
+
+        /**
          * Render privacy policy editor.
          */
         public function render_privacy_editor() {
@@ -1118,6 +1170,25 @@ if ( ! class_exists( 'FP_Privacy_Cookie_Policy' ) ) {
             </p>
             <p class="description">
                 <?php echo esc_html__( 'Imposta 0 per disattivare la pulizia automatica. Valori inferiori a 30 giorni vengono automaticamente aumentati.', 'fp-privacy-cookie-policy' ); ?>
+            </p>
+            <?php
+        }
+
+        /**
+         * Render consent cookie duration field.
+         */
+        public function render_consent_cookie_field() {
+            $options            = $this->get_settings();
+            $consent_cookie_days = isset( $options['consent_cookie_days'] ) ? (int) $options['consent_cookie_days'] : 0;
+            ?>
+            <p>
+                <label for="fp_consent_cookie_days">
+                    <input type="number" class="small-text" id="fp_consent_cookie_days" min="0" step="1" name="<?php echo esc_attr( self::OPTION_KEY ); ?>[consent_cookie_days]" value="<?php echo esc_attr( $consent_cookie_days ); ?>" />
+                    <?php echo esc_html__( 'Giorni di validità del consenso', 'fp-privacy-cookie-policy' ); ?>
+                </label>
+            </p>
+            <p class="description">
+                <?php echo esc_html__( 'Imposta 0 per chiedere il consenso a ogni sessione. Valori inferiori a 30 giorni vengono automaticamente aumentati, ma puoi modificare la soglia con il filtro fp_privacy_consent_cookie_min_days.', 'fp-privacy-cookie-policy' ); ?>
             </p>
             <?php
         }
@@ -1327,6 +1398,7 @@ if ( ! class_exists( 'FP_Privacy_Cookie_Policy' ) ) {
                     ),
                 ),
                 'retention_days'        => 365,
+                'consent_cookie_days'   => 180,
                 'google_defaults'        => array(
                     'analytics_storage'    => 'denied',
                     'ad_storage'           => 'denied',
@@ -1370,6 +1442,7 @@ if ( ! class_exists( 'FP_Privacy_Cookie_Policy' ) ) {
                 'banner'         => $localized['banner'],
                 'googleDefaults' => $options['google_defaults'],
                 'language'       => $localized['language'],
+                'cookieTtlDays'  => isset( $options['consent_cookie_days'] ) ? (int) $options['consent_cookie_days'] : 0,
                 'texts'          => array(
                     'manageConsent' => $text_values['manage_consent'],
                     'updatedAt'     => $text_values['updated_at'],

--- a/fp-privacy-cookie-policy/languages/fp-privacy-cookie-policy-en_US.po
+++ b/fp-privacy-cookie-policy/languages/fp-privacy-cookie-policy-en_US.po
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: FP Privacy and Cookie Policy 1.2.0\n"
+"Project-Id-Version: FP Privacy and Cookie Policy 1.3.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-09-24 16:28+0000\n"
 "PO-Revision-Date: 2025-09-24 16:28+0000\n"
@@ -53,6 +53,10 @@ msgstr "Google Consent Mode v2"
 #: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:212
 msgid "Stato di default"
 msgstr "Default state"
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:220
+msgid "Durata cookie di consenso"
+msgstr "Consent cookie duration"
 
 #: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:497
 #: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:527
@@ -466,6 +470,14 @@ msgstr "Log retention (days)"
 #: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:1033
 msgid "Imposta 0 per disattivare la pulizia automatica. Valori inferiori a 30 giorni vengono automaticamente aumentati."
 msgstr "Set 0 to disable automatic cleanup. Values lower than 30 days are automatically increased."
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:1143
+msgid "Giorni di validità del consenso"
+msgstr "Consent validity (days)"
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:1147
+msgid "Imposta 0 per chiedere il consenso a ogni sessione. Valori inferiori a 30 giorni vengono automaticamente aumentati, ma puoi modificare la soglia con il filtro fp_privacy_consent_cookie_min_days."
+msgstr "Set 0 to ask for consent every session. Values below 30 days are automatically increased, but you can adjust the threshold with the fp_privacy_consent_cookie_min_days filter."
 
 #: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:240
 #: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:256

--- a/fp-privacy-cookie-policy/languages/fp-privacy-cookie-policy.pot
+++ b/fp-privacy-cookie-policy/languages/fp-privacy-cookie-policy.pot
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: FP Privacy and Cookie Policy 1.2.0\n"
+"Project-Id-Version: FP Privacy and Cookie Policy 1.3.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-09-24 16:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
@@ -51,6 +51,10 @@ msgstr ""
 
 #: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:216
 msgid "Stato di default"
+msgstr ""
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:224
+msgid "Durata cookie di consenso"
 msgstr ""
 
 #: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:501
@@ -431,6 +435,14 @@ msgstr ""
 
 #: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:1033
 msgid "Imposta 0 per disattivare la pulizia automatica. Valori inferiori a 30 giorni vengono automaticamente aumentati."
+msgstr ""
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:1143
+msgid "Giorni di validità del consenso"
+msgstr ""
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:1147
+msgid "Imposta 0 per chiedere il consenso a ogni sessione. Valori inferiori a 30 giorni vengono automaticamente aumentati, ma puoi modificare la soglia con il filtro fp_privacy_consent_cookie_min_days."
 msgstr ""
 
 #: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:240

--- a/fp-privacy-cookie-policy/readme.txt
+++ b/fp-privacy-cookie-policy/readme.txt
@@ -4,7 +4,7 @@ Tags: gdpr, cookie banner, consent management, privacy policy, google consent mo
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.2.0
+Stable tag: 1.3.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -20,6 +20,7 @@ FP Privacy and Cookie Policy helps agencies and professionals implement a comple
 * Consent registry with anonymised IP address, AJAX logging and CSV export.
 * Native Google Consent Mode v2 integration and `dataLayer` events to orchestrate your tracking setup.
 * Configurable consent log retention with automatic cleanup and integration with the WordPress privacy export/erase tools.
+* Adjustable consent cookie duration to align banner re-consent with your legal requirements.
 
 == Installation ==
 1. Upload the `fp-privacy-cookie-policy` folder to the `/wp-content/plugins/` directory, or install the plugin from the WordPress plugin screen.
@@ -43,6 +44,10 @@ Usa la tab "Registro consensi" per consultare gli eventi registrati ed esportare
 3. Registro consensi con esportazione CSV e informazioni anonimizzate.
 
 == Changelog ==
+= 1.3.0 =
+* Added a dedicated control to configure the lifetime of the consent cookie, with safeguards and filters for advanced workflows.
+* Updated the frontend script to respect the configured consent lifetime while keeping secure defaults in place.
+
 = 1.2.0 =
 * Added retention controls for the consent registry with daily scheduled cleanup.
 * Integrated the consent logs with WordPress personal data exporter and eraser workflows.


### PR DESCRIPTION
## Summary
- add an admin control and sanitization for the consent cookie lifetime, including default configuration and localized strings
- update the frontend consent script to honour the configured cookie TTL while maintaining secure defaults
- bump the plugin version, readme and translation catalogues to document the new capability

## Testing
- php -l fp-privacy-cookie-policy/fp-privacy-cookie-policy.php

------
https://chatgpt.com/codex/tasks/task_e_68d4388e3e08832f8f58bd9b513d4981