### PR TITLE
Add persistent manage consent control

### DIFF
--- a/fp-privacy-cookie-policy/assets/css/banner.css
+++ b/fp-privacy-cookie-policy/assets/css/banner.css
@@ -250,6 +250,47 @@
     justify-content: flex-end;
 }
 
+.fp-consent-manage {
+    position: fixed;
+    right: 1.5rem;
+    bottom: 1.5rem;
+    z-index: 9998;
+    background: rgba(15, 23, 42, 0.92);
+    color: #f8fafc;
+    border: none;
+    border-radius: 9999px;
+    padding: 0.55rem 1.25rem;
+    box-shadow: 0 15px 30px rgba(15, 23, 42, 0.25);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-size: 0.9rem;
+    transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+    opacity: 0;
+}
+
+.fp-consent-manage .fp-consent-manage__label {
+    line-height: 1;
+}
+
+.fp-consent-manage:hover,
+.fp-consent-manage:focus {
+    background: rgba(15, 23, 42, 0.98);
+    color: #f8fafc;
+    transform: translateY(-1px);
+    box-shadow: 0 18px 38px rgba(15, 23, 42, 0.28);
+}
+
+.fp-consent-manage.is-visible {
+    opacity: 1;
+}
+
+.fp-consent-manage[hidden],
+.fp-consent-modal-open .fp-consent-manage {
+    opacity: 0;
+    pointer-events: none;
+}
+
 .fp-consent-modal-open {
     overflow: hidden;
 }
@@ -274,5 +315,12 @@
 
     .fp-consent-toggle {
         justify-content: flex-start;
+    }
+
+    .fp-consent-manage {
+        right: 1rem;
+        bottom: 1rem;
+        width: calc(100% - 2rem);
+        justify-content: center;
     }
 }

--- a/fp-privacy-cookie-policy/assets/js/fp-consent.js
+++ b/fp-privacy-cookie-policy/assets/js/fp-consent.js
@@ -22,6 +22,7 @@
     });
     var bannerElement;
     var modalElement;
+    var manageButton;
     var currentConsent = null;
 
     document.addEventListener('DOMContentLoaded', initialize);
@@ -29,6 +30,7 @@
     function initialize() {
         bannerElement = document.querySelector('.fp-consent-banner');
         modalElement = document.querySelector('.fp-consent-modal');
+        manageButton = document.querySelector('[data-consent-manage]');
 
         if (settings.language) {
             document.documentElement.setAttribute('data-fp-consent-lang', settings.language);
@@ -46,9 +48,11 @@
             var mapped = updateGoogleConsent(currentConsent, true);
             pushDataLayer(currentConsent, mapped);
             hideBanner();
+            toggleManageButton(true);
         } else {
             currentConsent = buildDefaultConsent();
             showBanner();
+            toggleManageButton(false);
         }
 
         bindActions();
@@ -171,6 +175,7 @@
         closeModal();
         dispatchConsentEvent(state, eventType);
         sendConsentToServer(state, eventType);
+        toggleManageButton(true);
     }
 
     function applyConsentToInterface(state) {
@@ -313,6 +318,9 @@
         modalElement.hidden = false;
         modalElement.classList.add('is-visible');
         document.body.classList.add('fp-consent-modal-open');
+        if (manageButton) {
+            manageButton.setAttribute('aria-expanded', 'true');
+        }
     }
 
     function closeModal() {
@@ -322,6 +330,9 @@
         modalElement.hidden = true;
         modalElement.classList.remove('is-visible');
         document.body.classList.remove('fp-consent-modal-open');
+        if (manageButton) {
+            manageButton.setAttribute('aria-expanded', 'false');
+        }
     }
 
     function showBanner() {
@@ -331,6 +342,7 @@
         if (bannerElement) {
             bannerElement.classList.add('is-visible');
         }
+        toggleManageButton(false);
     }
 
     function hideBanner() {
@@ -339,6 +351,9 @@
         }
         if (bannerElement) {
             bannerElement.classList.remove('is-visible');
+        }
+        if (currentConsent) {
+            toggleManageButton(true);
         }
     }
 
@@ -364,6 +379,24 @@
             window.gtag = function () {
                 window.dataLayer.push(arguments);
             };
+        }
+    }
+
+    function toggleManageButton(visible) {
+        if (!manageButton) {
+            return;
+        }
+
+        if (visible) {
+            manageButton.hidden = false;
+            manageButton.classList.add('is-visible');
+            manageButton.setAttribute('aria-hidden', 'false');
+            manageButton.setAttribute('aria-expanded', 'false');
+        } else {
+            manageButton.classList.remove('is-visible');
+            manageButton.hidden = true;
+            manageButton.setAttribute('aria-hidden', 'true');
+            manageButton.setAttribute('aria-expanded', 'false');
         }
     }
 })();

--- a/fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
+++ b/fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
@@ -1729,7 +1729,7 @@ if ( ! class_exists( 'FP_Privacy_Cookie_Policy' ) ) {
                     </div>
                 </div>
             </div>
-            <div class="fp-consent-modal" role="dialog" aria-modal="true" aria-labelledby="fp-consent-modal-title" data-language="<?php echo esc_attr( $localized['language'] ); ?>" hidden>
+            <div id="fp-consent-modal" class="fp-consent-modal" role="dialog" aria-modal="true" aria-labelledby="fp-consent-modal-title" data-language="<?php echo esc_attr( $localized['language'] ); ?>" hidden>
                 <div class="fp-consent-modal__overlay" data-consent-action="close"></div>
                 <div class="fp-consent-modal__dialog" role="document">
                     <button class="fp-consent-modal__close" type="button" aria-label="<?php echo esc_attr( $texts['modal_close'] ); ?>" data-consent-action="close">&times;</button>
@@ -1775,6 +1775,9 @@ if ( ! class_exists( 'FP_Privacy_Cookie_Policy' ) ) {
                     </div>
                 </div>
             </div>
+            <button class="fp-btn fp-btn-preferences fp-consent-manage" type="button" data-consent-manage data-consent-action="open-preferences" aria-haspopup="dialog" aria-controls="fp-consent-modal" aria-hidden="true" aria-expanded="false" hidden>
+                <span class="fp-consent-manage__label"><?php echo esc_html( $texts['manage_consent'] ); ?></span>
+            </button>
             <?php
         }
 


### PR DESCRIPTION
## Summary
- add an always-available "manage consent" control to the frontend banner markup
- update the consent script to toggle the new control and keep ARIA attributes in sync with the modal
- style the floating control so it remains usable on desktop and mobile layouts

## Testing
- php -l fp-privacy-cookie-policy/fp-privacy-cookie-policy.php

------
https://chatgpt.com/codex/tasks/task_e_68d43eaa73d0832faafd30eeaacce46d