### PR TITLE
Add Site Health coverage and plugin shortcuts

### DIFF
--- a/fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
+++ b/fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
@@ -81,6 +81,27 @@ if ( ! class_exists( 'FP_Privacy_Cookie_Policy' ) ) {
             add_filter( 'wp_privacy_personal_data_exporters', array( $this, 'register_privacy_exporter' ) );
             add_filter( 'wp_privacy_personal_data_erasers', array( $this, 'register_privacy_eraser' ) );
             add_action( 'admin_notices', array( $this, 'maybe_render_admin_notices' ) );
+            add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'add_plugin_action_links' ) );
+            add_filter( 'site_status_tests', array( $this, 'register_site_health_tests' ) );
+        }
+
+        /**
+         * Add quick links to the plugin entry inside the plugins list.
+         *
+         * @param string[] $links Existing action links.
+         *
+         * @return string[]
+         */
+        public function add_plugin_action_links( $links ) {
+            $settings_link = sprintf(
+                '<a href="%s">%s</a>',
+                esc_url( admin_url( 'admin.php?page=fp-privacy-cookie-policy' ) ),
+                esc_html__( 'Settings', 'fp-privacy-cookie-policy' )
+            );
+
+            array_unshift( $links, $settings_link );
+
+            return $links;
         }
 
         /**
@@ -2176,6 +2197,134 @@ if ( ! class_exists( 'FP_Privacy_Cookie_Policy' ) ) {
              * @param array $categories Plugin categories configuration.
              */
             return apply_filters( 'fp_privacy_normalized_consent_state', $normalized, $categories );
+        }
+
+        /**
+         * Register custom Site Health tests.
+         *
+         * @param array $tests Existing Site Health tests.
+         *
+         * @return array
+         */
+        public function register_site_health_tests( $tests ) {
+            if ( ! is_array( $tests ) ) {
+                $tests = array();
+            }
+
+            if ( ! isset( $tests['direct'] ) || ! is_array( $tests['direct'] ) ) {
+                $tests['direct'] = array();
+            }
+
+            $tests['direct']['fp_privacy_consent_table'] = array(
+                'label' => __( 'FP Privacy & Cookie Policy consent log table', 'fp-privacy-cookie-policy' ),
+                'test'  => array( $this, 'site_health_test_consent_table' ),
+            );
+
+            $tests['direct']['fp_privacy_cleanup_schedule'] = array(
+                'label' => __( 'FP Privacy & Cookie Policy consent cleanup schedule', 'fp-privacy-cookie-policy' ),
+                'test'  => array( $this, 'site_health_test_cleanup_schedule' ),
+            );
+
+            return $tests;
+        }
+
+        /**
+         * Site Health test that verifies the consent log table exists.
+         *
+         * @return array
+         */
+        public function site_health_test_consent_table() {
+            $badge = array(
+                'label' => __( 'FP Privacy & Cookie Policy', 'fp-privacy-cookie-policy' ),
+                'color' => 'blue',
+            );
+
+            if ( $this->consent_table_exists() ) {
+                return array(
+                    'status'      => 'good',
+                    'label'       => __( 'Consent log table is operational', 'fp-privacy-cookie-policy' ),
+                    'description' => sprintf(
+                        '<p>%s</p>',
+                        esc_html__( 'The consent log table is available and ready to store new consent events.', 'fp-privacy-cookie-policy' )
+                    ),
+                    'badge'       => $badge,
+                    'test'        => 'fp_privacy_consent_table',
+                );
+            }
+
+            $actions = sprintf(
+                '<p><a href="%1$s" class="button button-primary">%2$s</a></p>',
+                esc_url( admin_url( 'admin.php?page=fp-privacy-cookie-policy&tab=logs' ) ),
+                esc_html__( 'Open consent tools', 'fp-privacy-cookie-policy' )
+            );
+
+            return array(
+                'status'      => 'critical',
+                'label'       => __( 'Consent log table is missing', 'fp-privacy-cookie-policy' ),
+                'description' => sprintf(
+                    '<p>%s</p>',
+                    esc_html__( 'The consent log table could not be found. Consents will not be tracked until the table is recreated.', 'fp-privacy-cookie-policy' )
+                ),
+                'actions'     => $actions,
+                'badge'       => $badge,
+                'test'        => 'fp_privacy_consent_table',
+            );
+        }
+
+        /**
+         * Site Health test that checks whether the cleanup cron event is scheduled.
+         *
+         * @return array
+         */
+        public function site_health_test_cleanup_schedule() {
+            $badge = array(
+                'label' => __( 'FP Privacy & Cookie Policy', 'fp-privacy-cookie-policy' ),
+                'color' => 'blue',
+            );
+
+            $timestamp = wp_next_scheduled( self::CLEANUP_HOOK );
+
+            if ( ! $timestamp ) {
+                self::schedule_cleanup_event();
+                $timestamp = wp_next_scheduled( self::CLEANUP_HOOK );
+            }
+
+            if ( $timestamp ) {
+                $diff = human_time_diff( time(), $timestamp );
+
+                return array(
+                    'status'      => 'good',
+                    'label'       => __( 'Consent log cleanup is scheduled', 'fp-privacy-cookie-policy' ),
+                    'description' => sprintf(
+                        '<p>%s</p>',
+                        sprintf(
+                            /* translators: %s is a human readable time interval. */
+                            esc_html__( 'The consent log cleanup event is scheduled to run in %s.', 'fp-privacy-cookie-policy' ),
+                            esc_html( $diff )
+                        )
+                    ),
+                    'badge'       => $badge,
+                    'test'        => 'fp_privacy_cleanup_schedule',
+                );
+            }
+
+            $actions = sprintf(
+                '<p><a href="%1$s" class="button">%2$s</a></p>',
+                esc_url( admin_url( 'admin.php?page=fp-privacy-cookie-policy&tab=logs' ) ),
+                esc_html__( 'Review retention settings', 'fp-privacy-cookie-policy' )
+            );
+
+            return array(
+                'status'      => 'recommended',
+                'label'       => __( 'Consent log cleanup is not scheduled', 'fp-privacy-cookie-policy' ),
+                'description' => sprintf(
+                    '<p>%s</p>',
+                    esc_html__( 'The consent log cleanup task is not scheduled. Old consent records may accumulate over time.', 'fp-privacy-cookie-policy' )
+                ),
+                'actions'     => $actions,
+                'badge'       => $badge,
+                'test'        => 'fp_privacy_cleanup_schedule',
+            );
         }
 
         /**

--- a/fp-privacy-cookie-policy/languages/fp-privacy-cookie-policy-en_US.po
+++ b/fp-privacy-cookie-policy/languages/fp-privacy-cookie-policy-en_US.po
@@ -17,6 +17,10 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:99
+msgid "Settings"
+msgstr "Settings"
+
 #: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2527
 msgid "Questo plugin memorizza e registra le preferenze di consenso dei visitatori per aiutarvi a dimostrare la conformità al GDPR."
 msgstr "This plugin stores and logs visitors' consent preferences to help you demonstrate GDPR compliance."
@@ -577,3 +581,56 @@ msgstr "The consent log table is missing or corrupted. Recreate it to keep stori
 #: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:555
 msgid "Ricrea tabella registro consensi"
 msgstr "Recreate consent log table"
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2219
+msgid "FP Privacy & Cookie Policy consent log table"
+msgstr "FP Privacy & Cookie Policy consent log table"
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2224
+msgid "FP Privacy & Cookie Policy consent cleanup schedule"
+msgstr "FP Privacy & Cookie Policy consent cleanup schedule"
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2238
+msgid "FP Privacy & Cookie Policy"
+msgstr "FP Privacy & Cookie Policy"
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2245
+msgid "Consent log table is operational"
+msgstr "Consent log table is operational"
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2248
+msgid "The consent log table is available and ready to store new consent events."
+msgstr "The consent log table is available and ready to store new consent events."
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2258
+msgid "Open consent tools"
+msgstr "Open consent tools"
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2263
+msgid "Consent log table is missing"
+msgstr "Consent log table is missing"
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2266
+msgid "The consent log table could not be found. Consents will not be tracked until the table is recreated."
+msgstr "The consent log table could not be found. Consents will not be tracked until the table is recreated."
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2297
+msgid "Consent log cleanup is scheduled"
+msgstr "Consent log cleanup is scheduled"
+
+#. translators: %s is a human readable time interval.
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2302
+msgid "The consent log cleanup event is scheduled to run in %s."
+msgstr "The consent log cleanup event is scheduled to run in %s."
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2314
+msgid "Review retention settings"
+msgstr "Review retention settings"
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2319
+msgid "Consent log cleanup is not scheduled"
+msgstr "Consent log cleanup is not scheduled"
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2322
+msgid "The consent log cleanup task is not scheduled. Old consent records may accumulate over time."
+msgstr "The consent log cleanup task is not scheduled. Old consent records may accumulate over time."

--- a/fp-privacy-cookie-policy/languages/fp-privacy-cookie-policy.pot
+++ b/fp-privacy-cookie-policy/languages/fp-privacy-cookie-policy.pot
@@ -16,6 +16,10 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:99
+msgid "Settings"
+msgstr ""
+
 #: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2527
 msgid "Questo plugin memorizza e registra le preferenze di consenso dei visitatori per aiutarvi a dimostrare la conformità al GDPR."
 msgstr ""
@@ -542,4 +546,57 @@ msgstr ""
 
 #: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:555
 msgid "Ricrea tabella registro consensi"
+msgstr ""
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2219
+msgid "FP Privacy & Cookie Policy consent log table"
+msgstr ""
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2224
+msgid "FP Privacy & Cookie Policy consent cleanup schedule"
+msgstr ""
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2238
+msgid "FP Privacy & Cookie Policy"
+msgstr ""
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2245
+msgid "Consent log table is operational"
+msgstr ""
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2248
+msgid "The consent log table is available and ready to store new consent events."
+msgstr ""
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2258
+msgid "Open consent tools"
+msgstr ""
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2263
+msgid "Consent log table is missing"
+msgstr ""
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2266
+msgid "The consent log table could not be found. Consents will not be tracked until the table is recreated."
+msgstr ""
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2297
+msgid "Consent log cleanup is scheduled"
+msgstr ""
+
+#. translators: %s is a human readable time interval.
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2302
+msgid "The consent log cleanup event is scheduled to run in %s."
+msgstr ""
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2314
+msgid "Review retention settings"
+msgstr ""
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2319
+msgid "Consent log cleanup is not scheduled"
+msgstr ""
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:2322
+msgid "The consent log cleanup task is not scheduled. Old consent records may accumulate over time."
 msgstr ""


### PR DESCRIPTION
## Summary
- add a settings shortcut to the plugin action links for faster access to the configuration screen
- register Site Health checks that validate the consent table availability and the cleanup cron schedule
- update translation sources to expose the new strings for localisation

## Testing
- php -l fp-privacy-cookie-policy/fp-privacy-cookie-policy.php

------
https://chatgpt.com/codex/tasks/task_e_68d4493e297c832f8fb52811ce0cb244