### PR TITLE
Add WP-CLI tooling for consent log maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Plugin WordPress progettato per gestire privacy policy, cookie policy e consenso
 - Supporto per Google Tag Manager/eventi personalizzati via `dataLayer` e custom event `fp-consent-change`.
 - Traduzioni `en_US` pronte all'uso e file `.pot` per localizzazioni aggiuntive.
 - Impostazione del periodo di conservazione del registro con pulizia pianificata e integrazione con gli strumenti privacy di WordPress.
+- Comandi WP-CLI per verificare lo stato del registro, esportare i log e avviare la pulizia manuale.
 
 ## Installazione
 
@@ -47,6 +48,12 @@ Plugin WordPress progettato per gestire privacy policy, cookie policy e consenso
 - Puoi definire un periodo di conservazione automatica del registro per eliminare i consensi più datati.
 - Il registro è compatibile con gli strumenti di esportazione ed eliminazione dati di WordPress per gestire le richieste GDPR.
 - Gli ID consenso sono conservati in un cookie tecnico sicuro e anonimo (`fp_consent_state_id`).
+
+## Comandi WP-CLI
+
+- `wp fp-privacy status` mostra se la tabella del registro è disponibile, quanti eventi sono memorizzati e quando è prevista la prossima pulizia pianificata.
+- `wp fp-privacy cleanup` avvia la pulizia manuale del registro rispettando il periodo di conservazione configurato.
+- `wp fp-privacy export --file=percorso/file.csv` esporta i consensi in un file CSV, utile per audit e archiviazione offline.
 
 ## Suggerimenti legali
 

--- a/fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
+++ b/fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
@@ -3,7 +3,7 @@
  * Plugin Name: FP Privacy and Cookie Policy
  * Plugin URI:  https://example.com/
  * Description: Gestisci privacy policy, cookie policy e consenso informato in modo conforme al GDPR e al Google Consent Mode v2.
- * Version:     1.4.0
+ * Version:     1.5.0
  * Author:      FP Digital Assistant
  * Author URI:  https://example.com/
  * License:     GPL2
@@ -24,7 +24,7 @@ if ( ! class_exists( 'FP_Privacy_Cookie_Policy' ) ) {
     class FP_Privacy_Cookie_Policy {
 
         const OPTION_KEY        = 'fp_privacy_cookie_settings';
-        const VERSION           = '1.4.0';
+        const VERSION           = '1.5.0';
         const VERSION_OPTION    = 'fp_privacy_cookie_version';
         const CONSENT_COOKIE    = 'fp_consent_state';
         const CONSENT_TABLE     = 'fp_consent_logs';
@@ -2705,4 +2705,9 @@ if ( ! class_exists( 'FP_Privacy_Cookie_Policy' ) ) {
     register_uninstall_hook( __FILE__, array( 'FP_Privacy_Cookie_Policy', 'uninstall' ) );
 
     FP_Privacy_Cookie_Policy::instance();
+
+    if ( defined( 'WP_CLI' ) && WP_CLI ) {
+        require_once __DIR__ . '/includes/class-fp-privacy-cli.php';
+        \WP_CLI::add_command( 'fp-privacy', new FP_Privacy_CLI( FP_Privacy_Cookie_Policy::instance() ) );
+    }
 }

--- a/fp-privacy-cookie-policy/includes/class-fp-privacy-cli.php
+++ b/fp-privacy-cookie-policy/includes/class-fp-privacy-cli.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * WP-CLI commands for FP Privacy & Cookie Policy.
+ *
+ * @package FP_Privacy_Cookie_Policy
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'WP_CLI' ) ) {
+    return;
+}
+
+/**
+ * Manage the consent registry via WP-CLI.
+ */
+class FP_Privacy_CLI {
+
+    /**
+     * Plugin instance.
+     *
+     * @var FP_Privacy_Cookie_Policy
+     */
+    protected $plugin;
+
+    /**
+     * Constructor.
+     *
+     * @param FP_Privacy_Cookie_Policy $plugin Plugin instance.
+     */
+    public function __construct( FP_Privacy_Cookie_Policy $plugin ) {
+        $this->plugin = $plugin;
+    }
+
+    /**
+     * Display the current status of the consent registry and cleanup schedule.
+     *
+     * ## EXAMPLES
+     *
+     *     wp fp-privacy status
+     *
+     * @subcommand status
+     *
+     * @param array $args       Positional arguments.
+     * @param array $assoc_args Associative arguments.
+     */
+    public function status( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedParameter
+        global $wpdb;
+
+        $table_name = $this->get_consent_table_name( $wpdb );
+        $table_exists = $this->table_exists( $wpdb, $table_name );
+
+        if ( $table_exists ) {
+            \WP_CLI::success( __( 'Consent log table is operational.', 'fp-privacy-cookie-policy' ) );
+            $total = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table_name}" );
+            \WP_CLI::log( sprintf( __( 'Stored consent events: %d', 'fp-privacy-cookie-policy' ), $total ) );
+        } else {
+            \WP_CLI::warning( __( 'The consent log table is missing. Recreate it from the admin tools before logging consents.', 'fp-privacy-cookie-policy' ) );
+        }
+
+        $timestamp = wp_next_scheduled( FP_Privacy_Cookie_Policy::CLEANUP_HOOK );
+
+        if ( $timestamp ) {
+            $diff = human_time_diff( time(), $timestamp );
+            \WP_CLI::log( sprintf( __( 'Next cleanup runs in %s (scheduled for %s).', 'fp-privacy-cookie-policy' ), $diff, date_i18n( 'Y-m-d H:i:s', $timestamp ) ) );
+        } else {
+            \WP_CLI::warning( __( 'The consent cleanup event is not scheduled.', 'fp-privacy-cookie-policy' ) );
+        }
+    }
+
+    /**
+     * Manually run the consent log cleanup respecting the configured retention.
+     *
+     * ## EXAMPLES
+     *
+     *     wp fp-privacy cleanup
+     *
+     * @subcommand cleanup
+     *
+     * @param array $args       Positional arguments.
+     * @param array $assoc_args Associative arguments.
+     */
+    public function cleanup( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedParameter
+        global $wpdb;
+
+        $table_name = $this->get_consent_table_name( $wpdb );
+
+        if ( ! $this->table_exists( $wpdb, $table_name ) ) {
+            \WP_CLI::error( __( 'The consent log table could not be found.', 'fp-privacy-cookie-policy' ) );
+        }
+
+        $settings       = $this->plugin->get_settings();
+        $retention_days = $this->get_effective_retention_days( $settings );
+
+        if ( $retention_days < 1 ) {
+            \WP_CLI::warning( __( 'Automatic cleanup is disabled. Set a retention period before running the cleanup.', 'fp-privacy-cookie-policy' ) );
+            return;
+        }
+
+        $removed = $this->plugin->cleanup_consent_logs( $settings );
+
+        if ( $removed > 0 ) {
+            \WP_CLI::success( sprintf( __( 'Cleanup completed. %d entries were removed.', 'fp-privacy-cookie-policy' ), $removed ) );
+            return;
+        }
+
+        \WP_CLI::log( __( 'No consent entries matched the retention criteria.', 'fp-privacy-cookie-policy' ) );
+    }
+
+    /**
+     * Export the consent log to a CSV file.
+     *
+     * ## OPTIONS
+     *
+     * [--file=<file>]
+     * : Destination path for the CSV export.
+     *
+     * ## EXAMPLES
+     *
+     *     wp fp-privacy export --file=consents.csv
+     *
+     * @subcommand export
+     *
+     * @param array $args       Positional arguments.
+     * @param array $assoc_args Associative arguments.
+     */
+    public function export( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedParameter
+        global $wpdb;
+
+        $table_name = $this->get_consent_table_name( $wpdb );
+
+        if ( ! $this->table_exists( $wpdb, $table_name ) ) {
+            \WP_CLI::error( __( 'The consent log table could not be found.', 'fp-privacy-cookie-policy' ) );
+        }
+
+        if ( empty( $assoc_args['file'] ) ) {
+            \WP_CLI::error( __( 'You must provide a destination file via the --file parameter.', 'fp-privacy-cookie-policy' ) );
+        }
+
+        $file_path = wp_normalize_path( $assoc_args['file'] );
+        $directory = dirname( $file_path );
+
+        if ( ! is_dir( $directory ) && ! wp_mkdir_p( $directory ) ) {
+            \WP_CLI::error( sprintf( __( 'Unable to create the export directory: %s', 'fp-privacy-cookie-policy' ), $directory ) );
+        }
+
+        $handle = @fopen( $file_path, 'w' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen
+
+        if ( false === $handle ) {
+            \WP_CLI::error( sprintf( __( 'Unable to open %s for writing.', 'fp-privacy-cookie-policy' ), $file_path ) );
+        }
+
+        $batch_size = $this->get_export_batch_size();
+        fputcsv( $handle, array( 'created_at', 'consent_id', 'user_id', 'event_type', 'consent_state', 'ip_address', 'user_agent' ) );
+
+        $last_id = (int) $wpdb->get_var( "SELECT MAX(id) FROM {$table_name}" );
+        $exported = 0;
+
+        while ( $last_id > 0 ) {
+            $logs = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT * FROM {$table_name} WHERE id <= %d ORDER BY id DESC LIMIT %d",
+                    $last_id,
+                    $batch_size
+                )
+            );
+
+            if ( empty( $logs ) ) {
+                break;
+            }
+
+            foreach ( $logs as $log ) {
+                fputcsv(
+                    $handle,
+                    array(
+                        $log->created_at,
+                        $log->consent_id,
+                        $log->user_id,
+                        $log->event_type,
+                        $log->consent_state,
+                        $log->ip_address,
+                        $log->user_agent,
+                    )
+                );
+                $exported++;
+            }
+
+            $last_row = end( $logs );
+            $last_id  = $last_row ? ( (int) $last_row->id ) - 1 : 0;
+
+            if ( $last_id <= 0 || count( $logs ) < $batch_size ) {
+                break;
+            }
+        }
+
+        fclose( $handle );
+
+        \WP_CLI::success( sprintf( __( 'Export completed. %1$d entries written to %2$s.', 'fp-privacy-cookie-policy' ), $exported, $file_path ) );
+    }
+
+    /**
+     * Determine the consent table name.
+     *
+     * @param wpdb $wpdb WordPress database abstraction.
+     *
+     * @return string
+     */
+    protected function get_consent_table_name( $wpdb ) {
+        return $wpdb->prefix . FP_Privacy_Cookie_Policy::CONSENT_TABLE;
+    }
+
+    /**
+     * Check whether the consent table exists.
+     *
+     * @param wpdb   $wpdb       WordPress database abstraction.
+     * @param string $table_name Table name.
+     *
+     * @return bool
+     */
+    protected function table_exists( $wpdb, $table_name ) {
+        return $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name; // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+    }
+
+    /**
+     * Retrieve the export batch size, keeping compatibility with the filter used in the admin export.
+     *
+     * @return int
+     */
+    protected function get_export_batch_size() {
+        $batch_size = (int) apply_filters( 'fp_privacy_csv_export_batch_size', 500 );
+
+        if ( $batch_size < 1 ) {
+            $batch_size = 500;
+        }
+
+        return $batch_size;
+    }
+
+    /**
+     * Compute the effective retention period based on the plugin settings.
+     *
+     * @param array $settings Plugin settings.
+     *
+     * @return int
+     */
+    protected function get_effective_retention_days( array $settings ) {
+        $retention_days = isset( $settings['retention_days'] ) ? (int) $settings['retention_days'] : 0;
+        $retention_days = (int) apply_filters( 'fp_privacy_consent_retention_days', $retention_days, $settings );
+
+        if ( $retention_days < 0 ) {
+            $retention_days = 0;
+        }
+
+        return $retention_days;
+    }
+}

--- a/fp-privacy-cookie-policy/readme.txt
+++ b/fp-privacy-cookie-policy/readme.txt
@@ -4,7 +4,7 @@ Tags: gdpr, cookie banner, consent management, privacy policy, google consent mo
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.4.0
+Stable tag: 1.5.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,7 @@ FP Privacy and Cookie Policy helps agencies and professionals implement a comple
 * Native Google Consent Mode v2 integration and `dataLayer` events to orchestrate your tracking setup.
 * Configurable consent log retention with automatic cleanup and integration with the WordPress privacy export/erase tools.
 * Adjustable consent cookie duration to align banner re-consent with your legal requirements.
+* First-class WP-CLI commands to monitor the consent log, trigger cleanups and export CSV snapshots.
 
 == Installation ==
 1. Upload the `fp-privacy-cookie-policy` folder to the `/wp-content/plugins/` directory, or install the plugin from the WordPress plugin screen.
@@ -39,12 +40,23 @@ Certo. Il banner imposta i valori di default, aggiorna automaticamente i segnali
 = Come posso dimostrare il consenso? =
 Usa la tab "Registro consensi" per consultare gli eventi registrati ed esportare l'intero archivio in formato CSV. Puoi inoltre sfruttare gli strumenti di esportazione/cancellazione dati di WordPress per rispondere alle richieste degli interessati.
 
+== WP-CLI ==
+The plugin ships with a dedicated command namespace to automate maintenance tasks:
+
+* `wp fp-privacy status` — displays the consent table health, stored events and the next scheduled cleanup.
+* `wp fp-privacy cleanup` — runs the retention cleanup immediately while respecting your configuration.
+* `wp fp-privacy export --file=consents.csv` — saves the entire consent log to a CSV file optimised for large datasets.
+
 == Screenshots ==
 1. Banner cookie responsive con pulsanti principali e link alle preferenze.
 2. Modal delle preferenze con categorie e descrizioni personalizzabili.
 3. Registro consensi con esportazione CSV e informazioni anonimizzate.
 
 == Changelog ==
+= 1.5.0 =
+* Added WP-CLI commands to check the consent table health, trigger manual cleanups and export CSV snapshots without accessing the admin panel.
+* Documented the new automation workflow and bumped internal version metadata for the next stable release.
+
 = 1.4.0 =
 * Added a live consent update indicator with tooltip and time metadata stored alongside the consent state.
 * Improved dataLayer pushes and custom events by reusing the recorded timestamp for analytics consistency.
@@ -76,6 +88,8 @@ Usa la tab "Registro consensi" per consultare gli eventi registrati ed esportare
 * Initial release.
 
 == Upgrade Notice ==
+= 1.5.0 =
+Automate maintenance from the terminal with the new WP-CLI commands to monitor, export and clean consent logs.
 = 1.4.0 =
 Refresh any cached banner markup to surface the new consent status badge and timestamp metadata.
 = 1.2.0 =


### PR DESCRIPTION
## Summary
- add dedicated WP-CLI commands to inspect, export and clean the consent registry
- bump the plugin metadata to 1.5.0 and document the new automation workflow in the readme files

## Testing
- php -l fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
- php -l fp-privacy-cookie-policy/includes/class-fp-privacy-cli.php

------
https://chatgpt.com/codex/tasks/task_e_68d454cf375c832fba1a40a0127e4169