### PR TITLE
Add WP-CLI consent table recreation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Plugin WordPress progettato per gestire privacy policy, cookie policy e consenso
 - Supporto per Google Tag Manager/eventi personalizzati via `dataLayer` e custom event `fp-consent-change`.
 - Traduzioni `en_US` pronte all'uso e file `.pot` per localizzazioni aggiuntive.
 - Impostazione del periodo di conservazione del registro con pulizia pianificata e integrazione con gli strumenti privacy di WordPress.
-- Comandi WP-CLI per verificare lo stato del registro, esportare i log e avviare la pulizia manuale.
+- Comandi WP-CLI per verificare lo stato del registro, ricreare la tabella dei consensi, esportare i log e avviare la pulizia manuale.
 
 ## Installazione
 
@@ -52,6 +52,7 @@ Plugin WordPress progettato per gestire privacy policy, cookie policy e consenso
 ## Comandi WP-CLI
 
 - `wp fp-privacy status` mostra se la tabella del registro è disponibile, quanti eventi sono memorizzati e quando è prevista la prossima pulizia pianificata.
+- `wp fp-privacy recreate [--force]` ricrea la tabella del registro consensi e ripristina la pianificazione della pulizia.
 - `wp fp-privacy cleanup` avvia la pulizia manuale del registro rispettando il periodo di conservazione configurato.
 - `wp fp-privacy export --file=percorso/file.csv` esporta i consensi in un file CSV, utile per audit e archiviazione offline.
 
@@ -66,3 +67,11 @@ Questo plugin fornisce strumenti tecnici ma non sostituisce la consulenza legale
 ## Supporto
 
 Il plugin è pensato per sviluppatori e web agency. Puoi estenderlo registrando nuovi hook su `fp-consent-change` o leggendo il cookie `fp_consent_state` per gestire script personalizzati.
+
+## Changelog
+
+### 1.5.1
+- Aggiunto il comando WP-CLI `wp fp-privacy recreate` per ricreare rapidamente la tabella del registro e ripristinare la pianificazione della pulizia.
+
+### 1.5.0
+- Added WP-CLI commands to check the consent table health, trigger manual cleanups and export CSV snapshots without accessing the admin panel.

--- a/fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
+++ b/fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
@@ -3,7 +3,7 @@
  * Plugin Name: FP Privacy and Cookie Policy
  * Plugin URI:  https://example.com/
  * Description: Gestisci privacy policy, cookie policy e consenso informato in modo conforme al GDPR e al Google Consent Mode v2.
- * Version:     1.5.0
+ * Version:     1.5.1
  * Author:      FP Digital Assistant
  * Author URI:  https://example.com/
  * License:     GPL2
@@ -24,7 +24,7 @@ if ( ! class_exists( 'FP_Privacy_Cookie_Policy' ) ) {
     class FP_Privacy_Cookie_Policy {
 
         const OPTION_KEY        = 'fp_privacy_cookie_settings';
-        const VERSION           = '1.5.0';
+        const VERSION           = '1.5.1';
         const VERSION_OPTION    = 'fp_privacy_cookie_version';
         const CONSENT_COOKIE    = 'fp_consent_state';
         const CONSENT_TABLE     = 'fp_consent_logs';

--- a/fp-privacy-cookie-policy/includes/class-fp-privacy-cli.php
+++ b/fp-privacy-cookie-policy/includes/class-fp-privacy-cli.php
@@ -110,6 +110,51 @@ class FP_Privacy_CLI {
     }
 
     /**
+     * Recreate the consent log table if missing or when forced.
+     *
+     * ## OPTIONS
+     *
+     * [--force]
+     * : Recreate the table even if it already exists.
+     *
+     * ## EXAMPLES
+     *
+     *     wp fp-privacy recreate
+     *
+     * @subcommand recreate
+     *
+     * @param array $args       Positional arguments.
+     * @param array $assoc_args Associative arguments.
+     */
+    public function recreate( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedParameter
+        global $wpdb;
+
+        $table_name   = $this->get_consent_table_name( $wpdb );
+        $table_exists = $this->table_exists( $wpdb, $table_name );
+        $force        = ! empty( $assoc_args['force'] );
+
+        if ( $table_exists && ! $force ) {
+            \WP_CLI::success( __( 'Consent log table is operational.', 'fp-privacy-cookie-policy' ) );
+            return;
+        }
+
+        FP_Privacy_Cookie_Policy::create_consent_table();
+
+        if ( ! wp_next_scheduled( FP_Privacy_Cookie_Policy::CLEANUP_HOOK ) ) {
+            wp_schedule_event( time(), 'daily', FP_Privacy_Cookie_Policy::CLEANUP_HOOK );
+        }
+
+        update_option( FP_Privacy_Cookie_Policy::VERSION_OPTION, FP_Privacy_Cookie_Policy::VERSION );
+
+        if ( $this->table_exists( $wpdb, $table_name ) ) {
+            \WP_CLI::success( __( 'La tabella del registro consensi è stata ricreata correttamente.', 'fp-privacy-cookie-policy' ) );
+            return;
+        }
+
+        \WP_CLI::error( __( 'Impossibile creare la tabella del registro consensi. Verifica i permessi del database.', 'fp-privacy-cookie-policy' ) );
+    }
+
+    /**
      * Export the consent log to a CSV file.
      *
      * ## OPTIONS

--- a/fp-privacy-cookie-policy/languages/fp-privacy-cookie-policy-en_US.po
+++ b/fp-privacy-cookie-policy/languages/fp-privacy-cookie-policy-en_US.po
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: FP Privacy and Cookie Policy 1.3.1\n"
+"Project-Id-Version: FP Privacy and Cookie Policy 1.5.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-05-30 00:00+0000\n"
 "PO-Revision-Date: 2024-05-30 00:00+0000\n"

--- a/fp-privacy-cookie-policy/languages/fp-privacy-cookie-policy.pot
+++ b/fp-privacy-cookie-policy/languages/fp-privacy-cookie-policy.pot
@@ -5,7 +5,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: FP Privacy and Cookie Policy 1.3.1\n"
+"Project-Id-Version: FP Privacy and Cookie Policy 1.5.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-05-30 00:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/fp-privacy-cookie-policy/readme.txt
+++ b/fp-privacy-cookie-policy/readme.txt
@@ -4,7 +4,7 @@ Tags: gdpr, cookie banner, consent management, privacy policy, google consent mo
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.5.0
+Stable tag: 1.5.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,7 +22,7 @@ FP Privacy and Cookie Policy helps agencies and professionals implement a comple
 * Native Google Consent Mode v2 integration and `dataLayer` events to orchestrate your tracking setup.
 * Configurable consent log retention with automatic cleanup and integration with the WordPress privacy export/erase tools.
 * Adjustable consent cookie duration to align banner re-consent with your legal requirements.
-* First-class WP-CLI commands to monitor the consent log, trigger cleanups and export CSV snapshots.
+* First-class WP-CLI commands to monitor the consent log, recreate the table, trigger cleanups and export CSV snapshots.
 
 == Installation ==
 1. Upload the `fp-privacy-cookie-policy` folder to the `/wp-content/plugins/` directory, or install the plugin from the WordPress plugin screen.
@@ -44,6 +44,7 @@ Usa la tab "Registro consensi" per consultare gli eventi registrati ed esportare
 The plugin ships with a dedicated command namespace to automate maintenance tasks:
 
 * `wp fp-privacy status` — displays the consent table health, stored events and the next scheduled cleanup.
+* `wp fp-privacy recreate [--force]` — recreates the consent log table and restores the cleanup schedule without accessing wp-admin.
 * `wp fp-privacy cleanup` — runs the retention cleanup immediately while respecting your configuration.
 * `wp fp-privacy export --file=consents.csv` — saves the entire consent log to a CSV file optimised for large datasets.
 
@@ -53,6 +54,9 @@ The plugin ships with a dedicated command namespace to automate maintenance task
 3. Registro consensi con esportazione CSV e informazioni anonimizzate.
 
 == Changelog ==
+= 1.5.1 =
+* Added the `wp fp-privacy recreate` command to rebuild the consent log table and reschedule the cleanup cron job from the terminal.
+
 = 1.5.0 =
 * Added WP-CLI commands to check the consent table health, trigger manual cleanups and export CSV snapshots without accessing the admin panel.
 * Documented the new automation workflow and bumped internal version metadata for the next stable release.
@@ -88,6 +92,8 @@ The plugin ships with a dedicated command namespace to automate maintenance task
 * Initial release.
 
 == Upgrade Notice ==
+= 1.5.1 =
+Recreate the consent table from the terminal with `wp fp-privacy recreate` if you need to restore the consent registry after database maintenance.
 = 1.5.0 =
 Automate maintenance from the terminal with the new WP-CLI commands to monitor, export and clean consent logs.
 = 1.4.0 =


### PR DESCRIPTION
## Summary
- bump the plugin to version 1.5.1 and document the release in both readme files
- add a WP-CLI `wp fp-privacy recreate` command that rebuilds the consent log table and restores the cleanup schedule
- refresh documentation to mention the new command and update translation metadata

## Testing
- `find fp-privacy-cookie-policy -name "*.php" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68d4e717cf18832fb3257a9180b010aa