### PR TITLE
Improve consent modal accessibility

### DIFF
--- a/fp-privacy-cookie-policy/assets/js/fp-consent.js
+++ b/fp-privacy-cookie-policy/assets/js/fp-consent.js
@@ -32,6 +32,8 @@
     var statusElement;
     var statusValueElement;
     var preferredLocales = [];
+    var focusableSelector = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    var previouslyFocusedElement = null;
 
     function addPreferredLocale(locale) {
         if (!locale || typeof locale !== 'string') {
@@ -131,6 +133,7 @@
 
         updateUpdatedAtUI();
         bindActions();
+        document.addEventListener('keydown', handleDocumentKeydown, true);
     }
 
     function bindActions() {
@@ -496,12 +499,15 @@
             return;
         }
         applyConsentToInterface(currentConsent || buildDefaultConsent());
+        previouslyFocusedElement = document.activeElement;
         modalElement.hidden = false;
         modalElement.classList.add('is-visible');
+        modalElement.setAttribute('aria-hidden', 'false');
         document.body.classList.add('fp-consent-modal-open');
         if (manageButton) {
             manageButton.setAttribute('aria-expanded', 'true');
         }
+        focusModal();
     }
 
     function closeModal() {
@@ -510,10 +516,24 @@
         }
         modalElement.hidden = true;
         modalElement.classList.remove('is-visible');
+        modalElement.setAttribute('aria-hidden', 'true');
         document.body.classList.remove('fp-consent-modal-open');
         if (manageButton) {
             manageButton.setAttribute('aria-expanded', 'false');
         }
+        var focusTarget = null;
+        if (previouslyFocusedElement && typeof previouslyFocusedElement.focus === 'function' && document.contains(previouslyFocusedElement)) {
+            if (isElementVisible(previouslyFocusedElement)) {
+                focusTarget = previouslyFocusedElement;
+            }
+        }
+        if (!focusTarget && manageButton && typeof manageButton.focus === 'function') {
+            focusTarget = manageButton;
+        }
+        if (focusTarget) {
+            focusTarget.focus();
+        }
+        previouslyFocusedElement = null;
     }
 
     function showBanner() {
@@ -709,6 +729,115 @@
             text: text,
             iso: date.toISOString()
         };
+    }
+
+    function handleDocumentKeydown(event) {
+        if (!isModalOpen()) {
+            return;
+        }
+
+        var key = typeof event.key === 'string' ? event.key : '';
+        var keyCode = typeof event.keyCode === 'number' ? event.keyCode : 0;
+
+        if (key === 'Escape' || key === 'Esc' || keyCode === 27) {
+            event.preventDefault();
+            closeModal();
+            return;
+        }
+
+        if (key === 'Tab' || keyCode === 9) {
+            trapFocus(event);
+        }
+    }
+
+    function trapFocus(event) {
+        var focusable = getFocusableElements(modalElement);
+        if (focusable.length === 0) {
+            event.preventDefault();
+            if (modalElement && typeof modalElement.focus === 'function') {
+                modalElement.focus();
+            }
+            return;
+        }
+
+        var first = focusable[0];
+        var last = focusable[focusable.length - 1];
+        var activeElement = document.activeElement;
+
+        if (event.shiftKey) {
+            if (activeElement === first || activeElement === modalElement) {
+                event.preventDefault();
+                last.focus();
+            }
+            return;
+        }
+
+        if (activeElement === last) {
+            event.preventDefault();
+            first.focus();
+        }
+    }
+
+    function focusModal() {
+        if (!modalElement) {
+            return;
+        }
+
+        var focusable = getFocusableElements(modalElement);
+        if (focusable.length > 0) {
+            focusable[0].focus();
+            return;
+        }
+
+        if (typeof modalElement.focus === 'function') {
+            modalElement.focus();
+        }
+    }
+
+    function getFocusableElements(container) {
+        if (!container) {
+            return [];
+        }
+
+        var nodes = container.querySelectorAll(focusableSelector);
+        var elements = [];
+
+        for (var i = 0; i < nodes.length; i++) {
+            var element = nodes[i];
+            if (!element) {
+                continue;
+            }
+            if (element.disabled || element.getAttribute('aria-hidden') === 'true') {
+                continue;
+            }
+            if (!isElementVisible(element) && element !== document.activeElement) {
+                continue;
+            }
+            elements.push(element);
+        }
+
+        return elements;
+    }
+
+    function isElementVisible(element) {
+        if (!element) {
+            return false;
+        }
+
+        if (element.offsetWidth > 0 || element.offsetHeight > 0) {
+            return true;
+        }
+
+        if (typeof element.getClientRects === 'function') {
+            var rects = element.getClientRects();
+            return rects && rects.length > 0;
+        }
+
+        return false;
+    }
+
+    function isModalOpen() {
+        return !!(modalElement && modalElement.classList.contains('is-visible') && !modalElement.hidden);
     }
 
     function normalizeSameSite(value) {

--- a/fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
+++ b/fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
@@ -2034,7 +2034,7 @@ if ( ! class_exists( 'FP_Privacy_Cookie_Policy' ) ) {
                     </div>
                 </div>
             </div>
-            <div id="fp-consent-modal" class="fp-consent-modal" role="dialog" aria-modal="true" aria-labelledby="fp-consent-modal-title" data-language="<?php echo esc_attr( $localized['language'] ); ?>" hidden>
+            <div id="fp-consent-modal" class="fp-consent-modal" role="dialog" aria-modal="true" aria-labelledby="fp-consent-modal-title" data-language="<?php echo esc_attr( $localized['language'] ); ?>" aria-hidden="true" tabindex="-1" hidden>
                 <div class="fp-consent-modal__overlay" data-consent-action="close"></div>
                 <div class="fp-consent-modal__dialog" role="document">
                     <button class="fp-consent-modal__close" type="button" aria-label="<?php echo esc_attr( $texts['modal_close'] ); ?>" data-consent-action="close">&times;</button>


### PR DESCRIPTION
## Summary
- add ARIA metadata to the consent modal container for better focus management
- update the frontend script to trap focus, handle Escape, and restore focus when the modal closes

## Testing
- php -l fp-privacy-cookie-policy/fp-privacy-cookie-policy.php

------
https://chatgpt.com/codex/tasks/task_e_68d4fc5f91c0832fafa99a2e6a1f12e8