### PR TITLE
Add runtime requirement checks for environment compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Il plugin è pensato per sviluppatori e web agency. Puoi estenderlo registrando 
 
 ## Changelog
 
+-### 1.5.3
+- Aggiunto un controllo preventivo dei requisiti minimi (PHP e WordPress) con disattivazione automatica e avvisi in bacheca.
+
 ### 1.5.2
 - Aggiornata la documentazione ufficiale (README, readme.txt e changelog) con la cronologia completa delle release.
 - Allineati i riferimenti all'autore al nuovo maintainer Francesco Passeri.

--- a/fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
+++ b/fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
@@ -3,7 +3,7 @@
  * Plugin Name: FP Privacy and Cookie Policy
  * Plugin URI:  https://francescopasseri.com/
  * Description: Gestisci privacy policy, cookie policy e consenso informato in modo conforme al GDPR e al Google Consent Mode v2.
- * Version:     1.5.2
+ * Version:     1.5.3
  * Author:      Francesco Passeri
  * Author URI:  https://francescopasseri.com/
  * License:     GPL2
@@ -19,12 +19,89 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+if ( ! defined( 'FP_PRIVACY_COOKIE_POLICY_MIN_PHP' ) ) {
+    define( 'FP_PRIVACY_COOKIE_POLICY_MIN_PHP', '7.4' );
+}
+
+if ( ! defined( 'FP_PRIVACY_COOKIE_POLICY_MIN_WP' ) ) {
+    define( 'FP_PRIVACY_COOKIE_POLICY_MIN_WP', '6.0' );
+}
+
+$fp_privacy_cookie_policy_requirement_error = '';
+
+if ( version_compare( PHP_VERSION, FP_PRIVACY_COOKIE_POLICY_MIN_PHP, '<' ) ) {
+    $fp_privacy_cookie_policy_requirement_error = sprintf(
+        /* translators: %s is the minimum required PHP version. */
+        __( 'FP Privacy and Cookie Policy richiede PHP %s o superiore. Il plugin è stato disattivato.', 'fp-privacy-cookie-policy' ),
+        FP_PRIVACY_COOKIE_POLICY_MIN_PHP
+    );
+} elseif ( isset( $GLOBALS['wp_version'] ) && version_compare( $GLOBALS['wp_version'], FP_PRIVACY_COOKIE_POLICY_MIN_WP, '<' ) ) {
+    $fp_privacy_cookie_policy_requirement_error = sprintf(
+        /* translators: %s is the minimum required WordPress version. */
+        __( 'FP Privacy and Cookie Policy richiede WordPress %s o superiore. Il plugin è stato disattivato.', 'fp-privacy-cookie-policy' ),
+        FP_PRIVACY_COOKIE_POLICY_MIN_WP
+    );
+}
+
+if ( $fp_privacy_cookie_policy_requirement_error ) {
+    if ( ! function_exists( 'fp_privacy_cookie_policy_render_requirement_notice' ) ) {
+        /**
+         * Render environment requirement notices when the plugin cannot run.
+         */
+        function fp_privacy_cookie_policy_render_requirement_notice() {
+            global $fp_privacy_cookie_policy_requirement_error;
+
+            if ( empty( $fp_privacy_cookie_policy_requirement_error ) ) {
+                return;
+            }
+
+            printf(
+                '<div class="notice notice-error"><p>%s</p></div>',
+                esc_html( $fp_privacy_cookie_policy_requirement_error )
+            );
+        }
+    }
+
+    add_action( 'admin_notices', 'fp_privacy_cookie_policy_render_requirement_notice' );
+    add_action( 'network_admin_notices', 'fp_privacy_cookie_policy_render_requirement_notice' );
+
+    add_action(
+        'admin_init',
+        static function () {
+            if ( ! current_user_can( 'activate_plugins' ) ) {
+                return;
+            }
+
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+            deactivate_plugins( plugin_basename( __FILE__ ) );
+        }
+    );
+
+    register_activation_hook(
+        __FILE__,
+        static function () use ( $fp_privacy_cookie_policy_requirement_error ) {
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+            deactivate_plugins( plugin_basename( __FILE__ ) );
+
+            wp_die(
+                esc_html( $fp_privacy_cookie_policy_requirement_error ),
+                esc_html__( 'FP Privacy and Cookie Policy', 'fp-privacy-cookie-policy' ),
+                array( 'back_link' => true )
+            );
+        }
+    );
+
+    return;
+}
+
 if ( ! class_exists( 'FP_Privacy_Cookie_Policy' ) ) {
 
     class FP_Privacy_Cookie_Policy {
 
         const OPTION_KEY        = 'fp_privacy_cookie_settings';
-        const VERSION           = '1.5.2';
+        const VERSION           = '1.5.3';
         const VERSION_OPTION    = 'fp_privacy_cookie_version';
         const CONSENT_COOKIE    = 'fp_consent_state';
         const CONSENT_TABLE     = 'fp_consent_logs';

--- a/fp-privacy-cookie-policy/languages/fp-privacy-cookie-policy-en_US.po
+++ b/fp-privacy-cookie-policy/languages/fp-privacy-cookie-policy-en_US.po
@@ -5,9 +5,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: FP Privacy and Cookie Policy 1.5.2\n"
+"Project-Id-Version: FP Privacy and Cookie Policy 1.5.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-30 00:00+0000\n"
+"POT-Creation-Date: 2024-06-05 00:00+0000\n"
 "PO-Revision-Date: 2024-06-01 00:00+0000\n"
 "Last-Translator: Francesco Passeri <info@francescopasseri.com>\n"
 "Language-Team: none\n"
@@ -17,7 +17,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:99
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:129
+msgid "FP Privacy and Cookie Policy richiede PHP %s o superiore. Il plugin è stato disattivato."
+msgstr "FP Privacy and Cookie Policy requires PHP %s or higher. The plugin has been deactivated."
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:135
+msgid "FP Privacy and Cookie Policy richiede WordPress %s o superiore. Il plugin è stato disattivato."
+msgstr "FP Privacy and Cookie Policy requires WordPress %s or higher. The plugin has been deactivated."
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:171
 msgid "Settings"
 msgstr "Settings"
 

--- a/fp-privacy-cookie-policy/languages/fp-privacy-cookie-policy.pot
+++ b/fp-privacy-cookie-policy/languages/fp-privacy-cookie-policy.pot
@@ -5,9 +5,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: FP Privacy and Cookie Policy 1.5.2\n"
+"Project-Id-Version: FP Privacy and Cookie Policy 1.5.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-30 00:00+0000\n"
+"POT-Creation-Date: 2024-06-05 00:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Francesco Passeri <info@francescopasseri.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:99
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:129
+msgid "FP Privacy and Cookie Policy richiede PHP %s o superiore. Il plugin è stato disattivato."
+msgstr ""
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:135
+msgid "FP Privacy and Cookie Policy richiede WordPress %s o superiore. Il plugin è stato disattivato."
+msgstr ""
+
+#: fp-privacy-cookie-policy/fp-privacy-cookie-policy.php:171
 msgid "Settings"
 msgstr ""
 

--- a/fp-privacy-cookie-policy/readme.txt
+++ b/fp-privacy-cookie-policy/readme.txt
@@ -4,7 +4,7 @@ Tags: gdpr, cookie banner, consent management, privacy policy, google consent mo
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.5.2
+Stable tag: 1.5.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -64,6 +64,9 @@ Il plugin è mantenuto da [Francesco Passeri](https://francescopasseri.com/). Pe
 3. Registro consensi con esportazione CSV e informazioni anonimizzate.
 
 == Changelog ==
+= 1.5.3 =
+* Added proactive environment checks to disable the plugin when PHP or WordPress do not meet the minimum requirements.
+
 = 1.5.2 =
 * Updated all documentation (README, readme.txt, changelog) to provide a complete timeline of the changes shipped across releases.
 * Set Francesco Passeri as the official maintainer with updated contact details.
@@ -106,6 +109,9 @@ Il plugin è mantenuto da [Francesco Passeri](https://francescopasseri.com/). Pe
 * Initial release.
 
 == Upgrade Notice ==
+= 1.5.3 =
+Assicurati che l'installazione soddisfi i requisiti minimi (PHP 7.4, WordPress 6.0) per evitare la disattivazione automatica del plugin.
+
 = 1.5.2 =
 Rivedi la documentazione aggiornata e sostituisci eventuali riferimenti al vecchio maintainer con i nuovi contatti.
 


### PR DESCRIPTION
## Summary
- add guard clauses that deactivate the plugin when PHP or WordPress do not satisfy the declared minimum requirements
- surface clear admin notices and activation error messages for unmet requirements and define reusable constants for the target versions
- bump plugin version metadata/documentation and refresh translation templates with the new strings

## Testing
- php -l fp-privacy-cookie-policy/fp-privacy-cookie-policy.php

------
https://chatgpt.com/codex/tasks/task_e_68d51bd1a5f8832f9fee454f85641f9d