### PR TITLE
Add GitHub Actions workflow for plugin packaging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+*.min.js -diff
+*.min.css -diff
+*.map -diff
+*.zip -diff
+/.gitignore                 export-ignore
+/.gitattributes             export-ignore
+/.github/                   export-ignore
+/bin/package.sh             export-ignore
+/bin/qa-checklist.md        export-ignore
+/tests/                     export-ignore
+/dist/                      export-ignore
+/build/                     export-ignore
+/node_modules/              export-ignore
+/vendor/                    export-ignore
+/*.map                      export-ignore
+/*.min.*                    export-ignore

--- a/.github/workflows/build-zip.yml
+++ b/.github/workflows/build-zip.yml
@@ -1,0 +1,116 @@
+name: Build plugin ZIP
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Ref opzionale (branch/tag) da buildare'
+        required: false
+        default: ''
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      slug: ${{ steps.meta.outputs.slug }}
+      zip_name: ${{ steps.pkg.outputs.zip_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Setup PHP (solo per lint)
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: none
+          coverage: none
+
+      - name: Determina slug, file principale e versione
+        id: meta
+        run: |
+          set -euo pipefail
+          PLUGIN_SLUG="fp-privacy-cookie-policy"
+          MAIN_FILE="fp-privacy-cookie-policy.php"
+          if [ ! -f "$MAIN_FILE" ]; then
+            echo "File principale non trovato: $MAIN_FILE" >&2
+            exit 1
+          fi
+          VERSION="$(grep -E '^[[:space:]]*\*?[[:space:]]*Version:[[:space:]]*' "$MAIN_FILE" | head -n1 | sed -E 's/.*Version:[[:space:]]*//')"
+          VERSION_TRIM="$(echo "$VERSION" | tr -d '\r' | xargs)"
+          echo "version=$VERSION_TRIM" >> "$GITHUB_OUTPUT"
+          echo "slug=$PLUGIN_SLUG" >> "$GITHUB_OUTPUT"
+          echo "main=$MAIN_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Verifica corrispondenza tag ⇔ Version (se evento tag)
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF##*/}"
+          VERSION="${{ steps.meta.outputs.version }}"
+          TAG_VER="${TAG#v}"
+          if [ "$TAG_VER" != "$VERSION" ]; then
+            echo "ERRORE: il tag ($TAG) non corrisponde alla Version ($VERSION) nell'header del plugin." >&2
+            exit 1
+          fi
+          echo "OK: tag ($TAG) combacia con Version ($VERSION)."
+
+      - name: Lint PHP (sintassi)
+        run: |
+          set -euo pipefail
+          find . -type f -name "*.php" -not -path "./vendor/*" -not -path "./node_modules/*" -print0 | xargs -0 -n1 php -l
+
+      - name: Rendi eseguibile lo script di packaging
+        run: chmod +x bin/package.sh
+
+      - name: Costruisci ZIP del plugin
+        id: pkg
+        env:
+          PLUGIN_VERSION: ${{ steps.meta.outputs.version }}
+          PLUGIN_SLUG: ${{ steps.meta.outputs.slug }}
+        run: |
+          set -euo pipefail
+          bin/package.sh "$PLUGIN_SLUG" "$PLUGIN_VERSION"
+          echo "zip_path=./build/${PLUGIN_SLUG}-${PLUGIN_VERSION}.zip" >> "$GITHUB_OUTPUT"
+          echo "zip_name=${PLUGIN_SLUG}-${PLUGIN_VERSION}.zip" >> "$GITHUB_OUTPUT"
+
+      - name: Pubblica artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.pkg.outputs.zip_name }}
+          path: ${{ steps.pkg.outputs.zip_path }}
+          if-no-files-found: error
+          retention-days: 14
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scarica artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ format('{0}', needs.build.outputs.zip_name) }}
+          path: .
+
+      - name: Recupera artifact se nome non disponibile
+        run: |
+          set -euo pipefail
+          ZIP="$(ls -1 *.zip 2>/dev/null | head -n1 || true)"
+          if [ -z "$ZIP" ]; then
+            echo "Nessun ZIP trovato per la release." >&2
+            exit 1
+          fi
+          echo "ZIP=$ZIP" >> "$GITHUB_ENV"
+
+      - name: Pubblica release con asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ env.ZIP }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+vendor/
+dist/
+build/
+*.map
+*.min.*
+*.zip
+*.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# FP-Privacy-and-Cookie-Policy
+# FP Privacy and Cookie Policy
+
+Source for the WordPress plugin located in [`fp-privacy-cookie-policy/`](fp-privacy-cookie-policy/). Refer to the plugin's [README](fp-privacy-cookie-policy/README.md) and [readme.txt](fp-privacy-cookie-policy/readme.txt) for documentation.

--- a/bin/package.sh
+++ b/bin/package.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SLUG="${1:-fp-privacy-cookie-policy}"
+VERSION="${2:-0.1.0}"
+ROOT_DIR="$(pwd)"
+SOURCE_DIR="${ROOT_DIR}/${SLUG}"
+BUILD_DIR="${ROOT_DIR}/build"
+STAGING_DIR="${BUILD_DIR}/${SLUG}"
+
+if [ ! -d "${SOURCE_DIR}" ]; then
+  echo "Directory del plugin non trovato: ${SOURCE_DIR}" >&2
+  exit 1
+fi
+
+rm -rf "${BUILD_DIR}"
+mkdir -p "${STAGING_DIR}"
+
+INCLUDE_PATHS=(
+  "fp-privacy-cookie-policy.php"
+  "src"
+  "assets"
+  "blocks"
+  "templates"
+  "languages"
+  "inc"
+  "README.md"
+  "readme.txt"
+  "CHANGELOG.md"
+  "LICENSE"
+  ".gitattributes"
+  ".gitignore"
+  "bin/qa-checklist.md"
+)
+
+for p in "${INCLUDE_PATHS[@]}"; do
+  if [ -e "${SOURCE_DIR}/${p}" ]; then
+    if [ -d "${SOURCE_DIR}/${p}" ]; then
+      rsync -a --exclude ".DS_Store" "${SOURCE_DIR}/${p}" "${STAGING_DIR}/"
+    else
+      mkdir -p "${STAGING_DIR}/$(dirname "${p}")"
+      rsync -a "${SOURCE_DIR}/${p}" "${STAGING_DIR}/${p}"
+    fi
+  fi
+done
+
+find "${STAGING_DIR}" -type f \
+  \( -name "*.map" -o -name "*.min.*" -o -name "*.zip" -o -name "*.png" -o -name "*.jpg" -o -name "*.jpeg" -o -name "*.gif" \
+  -o -name "*.svg" -o -name "*.webp" -o -name "*.ico" -o -name "*.lock" -o -name "composer.lock" \) \
+  -delete
+
+rm -rf "${STAGING_DIR}/node_modules" "${STAGING_DIR}/vendor" "${STAGING_DIR}/dist" "${STAGING_DIR}/build" 2>/dev/null || true
+
+find "${STAGING_DIR}" -type f -name "*.php" -print0 | xargs -0 -n1 php -l
+
+pushd "${BUILD_DIR}" >/dev/null
+ZIP_NAME="${SLUG}-${VERSION}.zip"
+zip -r "${ZIP_NAME}" "${SLUG}" \
+  -x "*.DS_Store" -x "*node_modules/*" -x "*vendor/*" -x "*dist/*" -x "*build/*" -x "*.map" -x "*.min.*"
+popd >/dev/null
+
+echo "Creato: ${BUILD_DIR}/${ZIP_NAME}"

--- a/fp-privacy-cookie-policy/.gitattributes
+++ b/fp-privacy-cookie-policy/.gitattributes
@@ -1,0 +1,4 @@
+*.min.js -diff
+*.min.css -diff
+*.map -diff
+*.zip -diff

--- a/fp-privacy-cookie-policy/.gitignore
+++ b/fp-privacy-cookie-policy/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+vendor/
+dist/
+build/
+*.map
+*.min.*
+*.zip
+*.log
+.DS_Store

--- a/fp-privacy-cookie-policy/CHANGELOG.md
+++ b/fp-privacy-cookie-policy/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 0.1.0 — Initial alpha release
+- First public release with GDPR cookie banner, granular categories, consent registry (CSV export + retention), live palette preview, Google Consent Mode v2 integration, `fp-consent-change` CustomEvent, service detection with automatic privacy/cookie policy generation, shortcodes, Gutenberg blocks (ES5), WP-CLI commands, multisite provisioning, i18n, REST API, exporter/eraser, and cron-based cleanup.

--- a/fp-privacy-cookie-policy/LICENSE
+++ b/fp-privacy-cookie-policy/LICENSE
@@ -1,0 +1,11 @@
+GNU GENERAL PUBLIC LICENSE
+Version 2, June 1991
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+
+[The full GPL-2.0-or-later text continues...]
+

--- a/fp-privacy-cookie-policy/README.md
+++ b/fp-privacy-cookie-policy/README.md
@@ -1,0 +1,123 @@
+# FP Privacy and Cookie Policy
+
+FP Privacy and Cookie Policy is a WordPress plugin that delivers a full GDPR/ePrivacy consent management suite with Google Consent Mode v2 support. It automates banner rendering, consent state logging, document generation, WP-CLI tools, REST endpoints, and Gutenberg blocks without relying on a JavaScript build toolchain.
+
+## Key Features
+
+- GDPR-ready cookie banner with granular preferences, preview mode, accessibility-focused modal, and configurable palette.
+- Automated privacy and cookie policy generation based on detected integrations (Google Analytics 4, GTM, Meta Pixel, Hotjar, etc.).
+- Consent registry stored in a dedicated database table with hashed IPs, daily retention cleanup, CSV export, and analytics summary.
+- Google Consent Mode v2 orchestration and `dataLayer` integration with `fp-consent-change` CustomEvent.
+- Shortcodes, Block API v2 (ES5) blocks, and template overrides for complete front-end flexibility.
+- WP-CLI commands for status, cleanup, export, detection, and policy regeneration.
+- REST API endpoints (`fp-privacy/v1`) for saving consent and retrieving dashboards.
+- Multisite aware activation, per-site provisioning, and automatic policy page creation.
+- Extensive i18n with `fp-privacy` text domain and ready-to-translate POT file.
+- Admin UX covering settings, policy editor with diff preview, consent log table, CSV export, tools (import/export), and quick guide.
+
+## Installation
+
+1. Copy the `fp-privacy-cookie-policy` directory into your WordPress `wp-content/plugins/` directory.
+2. Activate **FP Privacy and Cookie Policy** from the Plugins screen (network activate on multisite if required).
+3. During activation the plugin will:
+   - Create the consent log table (`wp_fp_consent_log`).
+   - Generate privacy/cookie policy pages for the default locale (shortcodes inserted).
+   - Schedule the daily cleanup cron (`fp_privacy_cleanup`).
+
+## Configuration Overview
+
+1. Navigate to **Privacy & Cookie → Settings**.
+2. Configure active languages, banner copy, layout, palette, consent mode defaults, retention, and controller/DPO details.
+3. Use the live preview and color contrast checker to validate accessible palettes.
+4. Save settings and optionally bump the consent revision to re-trigger the banner for returning visitors.
+5. Use **Policy editor** to customize or regenerate documents. Regeneration invokes the detector registry and updates pages while bumping the revision.
+6. Review the **Consent log** for event breakdowns, filters, and CSV export.
+7. **Tools** allow JSON import/export, regeneration shortcuts, and revision reset. The quick guide documents shortcodes, blocks, and hooks.
+
+## Shortcodes
+
+- `[fp_privacy_policy]` – render the generated privacy policy.
+- `[fp_cookie_policy]` – render the generated cookie policy.
+- `[fp_cookie_preferences]` – output the cookie preferences management button.
+- `[fp_cookie_banner]` – manually place the banner in templates.
+
+## Gutenberg Blocks (ES5, No Build Step)
+
+Blocks are registered under the “FP Privacy” category:
+
+1. **Privacy Policy** – server-rendered via shortcode.
+2. **Cookie Policy** – server-rendered via shortcode.
+3. **Cookie Preferences** – injects the preferences button with aria attributes.
+4. **Cookie Banner** – renders the floating/bar banner wrapper.
+
+Scripts are loaded with the WordPress-provided globals (`wp.blocks`, `wp.element`, `wp.i18n`, `wp.editor`) and require no additional tooling.
+
+## Google Consent Mode v2 & Data Layer
+
+- Default consent signals are dispatched with `gtag('consent', 'default', {...})` at banner bootstrap.
+- When users update preferences the plugin sends `gtag('consent', 'update', {...})`, pushes `fp_consent_update` events into the `dataLayer`, and emits the `fp-consent-change` CustomEvent.
+- Use the README quick guide or `bin/qa-checklist.md` for GTM snippet examples and debugging pointers.
+
+## Detector & Policy Generator
+
+`FP\Privacy\Integrations\DetectorRegistry` inspects scripts, known option signatures, and cookie names to identify services. The generator groups services by category, provider, cookies, and legal basis to build localized documents using the templates in `templates/`.
+
+The detector map is filterable via `fp_privacy_services_registry` for custom services, and the generator output can be post-processed with `fp_privacy_policy_content` / `fp_cookie_policy_content` filters.
+
+## Consent Registry & Data Retention
+
+- Logs events (`accept_all`, `reject_all`, `consent`, `reset`, `revision_bump`) with hashed IP, user agent, language, revision, and JSON states.
+- Daily cleanup respects the `retention_days` option; the interval is filterable via `fp_privacy_csv_export_batch_size` and the cron schedule runs per site.
+- Exporter/Eraser handlers integrate with WordPress personal data tools.
+
+## WP-CLI Commands
+
+Run `wp help fp-privacy` for full documentation. Highlights:
+
+- `wp fp-privacy status` – Inspect table presence, event counts, and next cleanup.
+- `wp fp-privacy recreate [--force]` – Recreate the consent table and reschedule cron.
+- `wp fp-privacy cleanup` – Execute retention cleanup immediately.
+- `wp fp-privacy export --file=/path/to/file.csv` – Stream CSV export in batches.
+- `wp fp-privacy settings-export --file=/path/to/file.json`
+- `wp fp-privacy settings-import --file=/path/to/file.json`
+- `wp fp-privacy detect` – Output detected services.
+- `wp fp-privacy regenerate [--lang=LANG|all] [--bump-revision]`
+
+## REST API
+
+Namespace: `fp-privacy/v1`
+
+- `GET /consent/summary` (admin capability) – returns 30-day event stats and revision info.
+- `POST /consent` – stores granular consent with nonce and rate limiting.
+- `POST /revision/bump` – admin endpoint mirroring the revision bump action.
+
+## Hooks & Filters
+
+- `fp_consent_update( $states, $event, $revision )`
+- `fp_privacy_settings_imported( $settings )`
+- `fp_privacy_policy_content` / `fp_cookie_policy_content`
+- `fp_privacy_services_registry`
+- `fp_privacy_service_purpose_{key}`
+- `fp_privacy_csv_export_batch_size`
+- `fp_privacy_cookie_duration_days`
+
+## Multisite Support
+
+- Network activation provisions all sites by creating tables, options, and scheduling cleanup events.
+- New sites added via `wpmu_new_blog` trigger automatic provisioning.
+- Each site retains independent settings and consent registries.
+
+## Development Notes
+
+- PHP 7.4+, WordPress 6.2+ compatibility target.
+- No compiled assets or `.min` files; ES5 scripts enqueue directly.
+- Autoloading uses a lightweight PSR-4 routine scoped to the `FP\Privacy` namespace.
+- Tests are not bundled; follow the QA checklist for manual verification.
+
+## License
+
+Distributed under the [GNU General Public License v2 or later](LICENSE).
+
+## Disclaimer
+
+This plugin provides technical tooling to support privacy compliance workflows. Always review generated documents and consent flows with your legal counsel.

--- a/fp-privacy-cookie-policy/assets/css/admin.css
+++ b/fp-privacy-cookie-policy/assets/css/admin.css
@@ -1,0 +1,86 @@
+.fp-privacy-settings .fp-privacy-language-panel,
+.fp-privacy-settings .fp-privacy-org,
+.fp-privacy-settings .fp-privacy-layout,
+.fp-privacy-settings .fp-privacy-palette,
+.fp-privacy-settings .fp-privacy-consent-mode {
+margin-bottom: 24px;
+background: #fff;
+padding: 20px;
+border: 1px solid #d1d5db;
+border-radius: 8px;
+}
+
+.fp-privacy-settings label {
+display: block;
+margin-bottom: 12px;
+}
+
+.fp-privacy-settings label span {
+display: block;
+font-weight: 600;
+margin-bottom: 4px;
+}
+
+.fp-privacy-palette label {
+display: inline-block;
+margin-right: 20px;
+}
+
+.fp-privacy-detected .status-detected {
+color: #047857;
+font-weight: 600;
+}
+
+.fp-privacy-consent-log table.details summary {
+cursor: pointer;
+}
+
+.fp-privacy-diff {
+background: #fff;
+border: 1px solid #d1d5db;
+padding: 16px;
+border-radius: 8px;
+overflow: auto;
+}
+
+.fp-privacy-consent-log .fp-privacy-event {
+display: inline-block;
+padding: 4px 8px;
+border-radius: 999px;
+font-size: 12px;
+text-transform: uppercase;
+letter-spacing: 0.02em;
+}
+
+.fp-privacy-consent-log .fp-privacy-event-consent { background: #ecfdf5; color: #065f46; }
+.fp-privacy-consent-log .fp-privacy-event-accept_all { background: #eff6ff; color: #1d4ed8; }
+.fp-privacy-consent-log .fp-privacy-event-reject_all { background: #fef2f2; color: #b91c1c; }
+.fp-privacy-consent-log .fp-privacy-event-reset { background: #fef3c7; color: #92400e; }
+.fp-privacy-consent-log .fp-privacy-event-revision_bump { background: #ede9fe; color: #5b21b6; }
+
+.fp-privacy-consent-log .tablenav-pages {
+margin: 1rem 0;
+}
+
+.fp-privacy-consent-log .fp-privacy-summary ul {
+display: flex;
+flex-wrap: wrap;
+gap: 16px;
+padding-left: 0;
+list-style: none;
+}
+
+.fp-privacy-consent-log .fp-privacy-summary li {
+background: #fff;
+border: 1px solid #d1d5db;
+padding: 12px;
+border-radius: 6px;
+}
+
+.fp-privacy-policy-editor .wp-editor-area {
+min-height: 200px;
+}
+
+.fp-privacy-policy-editor .fp-privacy-regenerate {
+margin-top: 20px;
+}

--- a/fp-privacy-cookie-policy/assets/css/banner.css
+++ b/fp-privacy-cookie-policy/assets/css/banner.css
@@ -1,0 +1,189 @@
+:root {
+--fp-privacy-surface_bg: #0b1220;
+--fp-privacy-surface_text: #ffffff;
+--fp-privacy-button_primary_bg: #4c7cf6;
+--fp-privacy-button_primary_tx: #ffffff;
+--fp-privacy-button_secondary_bg: #e5e7eb;
+--fp-privacy-button_secondary_tx: #111827;
+--fp-privacy-link: #2563eb;
+--fp-privacy-border: #d1d5db;
+--fp-privacy-focus: #3b82f6;
+}
+
+#fp-privacy-banner-root,
+.fp-privacy-banner-shortcode {
+font-family: inherit;
+}
+
+.fp-privacy-banner {
+position: fixed;
+left: 50%;
+transform: translateX(-50%);
+z-index: 99999;
+max-width: 640px;
+background: var(--fp-privacy-surface_bg);
+color: var(--fp-privacy-surface_text);
+border-radius: 12px;
+padding: 24px;
+box-shadow: 0 20px 40px rgba(11, 18, 32, 0.25);
+border: 1px solid var(--fp-privacy-border);
+line-height: 1.6;
+}
+
+.fp-privacy-banner h2 {
+margin-top: 0;
+font-size: 1.25rem;
+}
+
+.fp-privacy-banner p {
+margin-bottom: 1rem;
+}
+
+.fp-privacy-banner-buttons {
+display: flex;
+flex-wrap: wrap;
+gap: 12px;
+}
+
+.fp-privacy-button {
+cursor: pointer;
+border-radius: 6px;
+font-weight: 600;
+padding: 0.6rem 1.4rem;
+border: 2px solid transparent;
+transition: background 0.2s ease, color 0.2s ease;
+}
+
+.fp-privacy-button-primary {
+background: var(--fp-privacy-button_primary_bg);
+color: var(--fp-privacy-button_primary_tx);
+}
+
+.fp-privacy-button-primary:focus,
+.fp-privacy-button-secondary:focus {
+outline: 3px solid var(--fp-privacy-focus);
+outline-offset: 2px;
+}
+
+.fp-privacy-button-secondary {
+background: var(--fp-privacy-button_secondary_bg);
+color: var(--fp-privacy-button_secondary_tx);
+}
+
+.fp-privacy-link {
+color: var(--fp-privacy-link);
+text-decoration: underline;
+}
+
+.fp-privacy-modal-overlay {
+position: fixed;
+top: 0;
+left: 0;
+width: 100%;
+height: 100%;
+background: rgba(17, 24, 39, 0.65);
+z-index: 99998;
+display: none;
+align-items: center;
+justify-content: center;
+padding: 1.5rem;
+}
+
+.fp-privacy-modal {
+background: #ffffff;
+color: #111827;
+max-width: 720px;
+width: 100%;
+border-radius: 12px;
+padding: 2rem;
+box-shadow: 0 20px 40px rgba(15, 23, 42, 0.3);
+position: relative;
+}
+
+.fp-privacy-modal h2 {
+margin-top: 0;
+}
+
+.fp-privacy-modal button.close {
+position: absolute;
+top: 1rem;
+right: 1rem;
+background: transparent;
+border: 0;
+font-size: 1.4rem;
+cursor: pointer;
+color: inherit;
+}
+
+.fp-privacy-category {
+border: 1px solid #e5e7eb;
+border-radius: 8px;
+padding: 1rem;
+margin-bottom: 1rem;
+}
+
+.fp-privacy-category h3 {
+margin-top: 0;
+}
+
+.fp-privacy-switch {
+display: flex;
+align-items: center;
+gap: 12px;
+}
+
+.fp-privacy-switch input[type="checkbox"] {
+width: 44px;
+height: 24px;
+appearance: none;
+background: #d1d5db;
+border-radius: 999px;
+position: relative;
+cursor: pointer;
+transition: background 0.2s ease;
+}
+
+.fp-privacy-switch input[type="checkbox"]:checked {
+background: #2563eb;
+}
+
+.fp-privacy-switch input[type="checkbox"]::after {
+content: '';
+position: absolute;
+top: 2px;
+left: 2px;
+width: 20px;
+height: 20px;
+background: #ffffff;
+border-radius: 50%;
+transition: transform 0.2s ease;
+}
+
+.fp-privacy-switch input[type="checkbox"]:checked::after {
+transform: translateX(20px);
+}
+
+.fp-privacy-modal-actions {
+display: flex;
+gap: 12px;
+margin-top: 1.5rem;
+flex-wrap: wrap;
+}
+
+.fp-privacy-cookie-debug {
+margin-top: 1.5rem;
+font-size: 0.875rem;
+background: rgba(37, 99, 235, 0.1);
+padding: 1rem;
+border-radius: 8px;
+}
+
+@media (max-width: 782px) {
+.fp-privacy-banner {
+width: calc(100% - 32px);
+left: 16px;
+right: 16px;
+transform: none;
+bottom: 16px;
+}
+}

--- a/fp-privacy-cookie-policy/assets/js/admin.js
+++ b/fp-privacy-cookie-policy/assets/js/admin.js
@@ -1,0 +1,54 @@
+(function ($) {
+'use strict';
+
+function getLuminance(hex) {
+hex = hex.replace('#', '');
+if ( hex.length === 3 ) {
+hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+}
+var r = parseInt( hex.substr( 0, 2 ), 16 ) / 255;
+var g = parseInt( hex.substr( 2, 2 ), 16 ) / 255;
+var b = parseInt( hex.substr( 4, 2 ), 16 ) / 255;
+var arr = [ r, g, b ].map( function ( value ) {
+return value <= 0.03928 ? value / 12.92 : Math.pow( ( value + 0.055 ) / 1.055, 2.4 );
+} );
+return 0.2126 * arr[0] + 0.7152 * arr[1] + 0.0722 * arr[2];
+}
+
+function contrastRatio(hex1, hex2) {
+var l1 = getLuminance( hex1 );
+var l2 = getLuminance( hex2 );
+var lighter = Math.max( l1, l2 );
+var darker = Math.min( l1, l2 );
+return ( lighter + 0.05 ) / ( darker + 0.05 );
+}
+
+$( function () {
+var form = $( '.fp-privacy-settings-form' );
+if ( ! form.length ) {
+return;
+}
+
+var notice = $( '<div class="notice notice-warning" style="display:none;"><p></p></div>' );
+form.prepend( notice );
+
+function evaluateContrast() {
+var surface = form.find( 'input[name="banner_layout[palette][surface_bg]"]' ).val();
+var text = form.find( 'input[name="banner_layout[palette][surface_text]"]' ).val();
+if ( ! surface || ! text ) {
+notice.hide();
+return;
+}
+var ratio = contrastRatio( surface, text );
+if ( ratio < 4.5 ) {
+notice.find( 'p' ).text( window.fpPrivacyL10n ? window.fpPrivacyL10n.lowContrast : 'The contrast ratio between background and text is below 4.5:1. Please adjust your palette.' );
+notice.show();
+} else {
+notice.hide();
+}
+}
+
+form.on( 'change', 'input[type="color"]', evaluateContrast );
+evaluateContrast();
+});
+})( window.jQuery );

--- a/fp-privacy-cookie-policy/assets/js/banner.js
+++ b/fp-privacy-cookie-policy/assets/js/banner.js
@@ -1,0 +1,358 @@
+(function () {
+'use strict';
+
+var data = window.FP_PRIVACY_DATA;
+if ( ! data ) {
+return;
+}
+
+var root = document.getElementById( 'fp-privacy-banner-root' );
+if ( ! root ) {
+var shortcodeRoot = document.querySelector( '[data-fp-privacy-banner]' );
+if ( shortcodeRoot ) {
+root = shortcodeRoot;
+}
+}
+
+if ( ! root ) {
+return;
+}
+
+var state = data.options.state || {};
+var categories = data.options.categories || {};
+var layout = data.options.layout || {};
+var texts = data.options.texts || {};
+var rest = data.rest || {};
+var consentDefaults = data.options.mode || {};
+
+var dataset = root.dataset || {};
+var forceDisplay = false;
+
+if ( dataset.layoutType === 'bar' || dataset.layoutType === 'floating' ) {
+layout.type = dataset.layoutType;
+}
+
+if ( dataset.layoutPosition === 'top' || dataset.layoutPosition === 'bottom' ) {
+layout.position = dataset.layoutPosition;
+}
+
+if ( dataset.lang ) {
+state.lang = dataset.lang;
+}
+
+if ( dataset.forceDisplay === '1' || dataset.forceDisplay === 'true' ) {
+forceDisplay = true;
+}
+
+var modalOverlay;
+var modal;
+var banner;
+
+document.addEventListener( 'DOMContentLoaded', function () {
+buildBanner();
+if ( state.should_display || forceDisplay ) {
+showBanner();
+}
+});
+
+function buildBanner() {
+banner = document.createElement( 'div' );
+banner.className = 'fp-privacy-banner';
+if ( layout.type === 'bar' ) {
+banner.style.width = '100%';
+banner.style.left = '0';
+banner.style.transform = 'none';
+banner.style.maxWidth = '100%';
+banner.style.borderRadius = '0';
+banner.style[ layout.position === 'top' ? 'top' : 'bottom' ] = '0';
+} else {
+banner.style.bottom = layout.position === 'top' ? '' : '24px';
+banner.style.top = layout.position === 'top' ? '24px' : '';
+}
+
+var title = document.createElement( 'h2' );
+title.textContent = texts.title || '';
+banner.appendChild( title );
+
+var message = document.createElement( 'p' );
+message.innerHTML = texts.message || '';
+banner.appendChild( message );
+
+if ( texts.link_policy ) {
+var link = document.createElement( 'a' );
+link.href = texts.link_policy;
+link.className = 'fp-privacy-link';
+link.setAttribute( 'target', '_blank' );
+link.rel = 'noopener noreferrer';
+link.textContent = texts.link_policy;
+banner.appendChild( link );
+}
+
+var buttons = document.createElement( 'div' );
+buttons.className = 'fp-privacy-banner-buttons';
+
+var accept = createButton( texts.btn_accept, 'fp-privacy-button fp-privacy-button-primary' );
+accept.addEventListener( 'click', function () {
+handleAcceptAll();
+});
+buttons.appendChild( accept );
+
+var reject = createButton( texts.btn_reject, 'fp-privacy-button fp-privacy-button-secondary' );
+reject.addEventListener( 'click', function () {
+handleRejectAll();
+});
+buttons.appendChild( reject );
+
+var prefs = createButton( texts.btn_prefs, 'fp-privacy-button fp-privacy-button-secondary' );
+prefs.addEventListener( 'click', function () {
+openModal();
+});
+buttons.appendChild( prefs );
+
+banner.appendChild( buttons );
+
+root.appendChild( banner );
+buildModal();
+
+if ( state.preview_mode ) {
+renderCookieDebug();
+}
+}
+
+function createButton( label, className ) {
+var btn = document.createElement( 'button' );
+btn.type = 'button';
+btn.className = className;
+btn.textContent = label || '';
+return btn;
+}
+
+function buildModal() {
+modalOverlay = document.createElement( 'div' );
+modalOverlay.className = 'fp-privacy-modal-overlay';
+modalOverlay.setAttribute( 'role', 'dialog' );
+modalOverlay.setAttribute( 'aria-modal', 'true' );
+
+modal = document.createElement( 'div' );
+modal.className = 'fp-privacy-modal';
+
+var close = document.createElement( 'button' );
+close.type = 'button';
+close.className = 'close';
+close.setAttribute( 'aria-label', 'Close preferences' );
+close.innerHTML = '&times;';
+close.addEventListener( 'click', closeModal );
+modal.appendChild( close );
+
+var heading = document.createElement( 'h2' );
+heading.textContent = texts.btn_prefs || 'Preferences';
+modal.appendChild( heading );
+
+for ( var key in categories ) {
+if ( ! categories.hasOwnProperty( key ) ) {
+continue;
+}
+var cat = categories[ key ];
+var wrapper = document.createElement( 'div' );
+wrapper.className = 'fp-privacy-category';
+
+var title = document.createElement( 'h3' );
+title.textContent = cat.label || key;
+wrapper.appendChild( title );
+
+var desc = document.createElement( 'p' );
+desc.innerHTML = cat.description || '';
+wrapper.appendChild( desc );
+
+var toggle = document.createElement( 'label' );
+toggle.className = 'fp-privacy-switch';
+
+var checkbox = document.createElement( 'input' );
+checkbox.type = 'checkbox';
+checkbox.value = key;
+checkbox.name = 'fp_privacy_category_' + key;
+checkbox.checked = ! cat.locked;
+checkbox.disabled = !! cat.locked;
+checkbox.dataset.category = key;
+
+toggle.appendChild( checkbox );
+
+var toggleText = document.createElement( 'span' );
+toggleText.textContent = cat.locked ? 'Always active' : 'Enabled';
+toggle.appendChild( toggleText );
+
+wrapper.appendChild( toggle );
+modal.appendChild( wrapper );
+}
+
+var actions = document.createElement( 'div' );
+actions.className = 'fp-privacy-modal-actions';
+
+var save = createButton( 'Save preferences', 'fp-privacy-button fp-privacy-button-primary' );
+save.addEventListener( 'click', handleSavePreferences );
+actions.appendChild( save );
+
+var acceptAll = createButton( texts.btn_accept, 'fp-privacy-button fp-privacy-button-secondary' );
+acceptAll.addEventListener( 'click', function () {
+handleAcceptAll();
+closeModal();
+});
+actions.appendChild( acceptAll );
+
+modal.appendChild( actions );
+modalOverlay.appendChild( modal );
+document.body.appendChild( modalOverlay );
+
+modalOverlay.addEventListener( 'click', function ( event ) {
+if ( event.target === modalOverlay ) {
+closeModal();
+}
+});
+
+document.addEventListener( 'keydown', function ( event ) {
+if ( 'Escape' === event.key && modalOverlay.style.display === 'flex' ) {
+closeModal();
+}
+});
+}
+
+function showBanner() {
+banner.style.display = 'block';
+}
+
+function hideBanner() {
+banner.style.display = 'none';
+}
+
+function openModal() {
+modalOverlay.style.display = 'flex';
+var firstInput = modal.querySelector( 'input[type="checkbox"]:not(:disabled)' );
+if ( firstInput ) {
+firstInput.focus();
+}
+}
+
+function closeModal() {
+modalOverlay.style.display = 'none';
+}
+
+function buildConsentPayload( grantAll, denyAll ) {
+var payload = {};
+for ( var key in categories ) {
+if ( ! categories.hasOwnProperty( key ) ) {
+continue;
+}
+var cat = categories[ key ];
+if ( cat.locked ) {
+payload[ key ] = true;
+continue;
+}
+
+if ( grantAll ) {
+payload[ key ] = true;
+} else if ( denyAll ) {
+payload[ key ] = false;
+} else {
+var input = modal.querySelector( 'input[data-category="' + key + '"]' );
+payload[ key ] = input ? input.checked : false;
+}
+}
+
+return payload;
+}
+
+function mapToConsentMode( payload ) {
+var result = {};
+for ( var key in consentDefaults ) {
+if ( consentDefaults.hasOwnProperty( key ) ) {
+result[ key ] = consentDefaults[ key ];
+}
+}
+
+var marketing = payload.marketing === true;
+var statistics = payload.statistics === true;
+var preferences = payload.preferences === true;
+
+if ( statistics ) {
+result.analytics_storage = 'granted';
+} else {
+result.analytics_storage = 'denied';
+}
+
+if ( marketing ) {
+result.ad_storage = 'granted';
+result.ad_user_data = 'granted';
+result.ad_personalization = 'granted';
+} else {
+result.ad_storage = 'denied';
+result.ad_user_data = 'denied';
+result.ad_personalization = 'denied';
+}
+
+result.functionality_storage = preferences || payload.necessary ? 'granted' : 'denied';
+result.security_storage = 'granted';
+
+return result;
+}
+
+function handleAcceptAll() {
+var payload = buildConsentPayload( true, false );
+persistConsent( 'accept_all', payload );
+}
+
+function handleRejectAll() {
+var payload = buildConsentPayload( false, true );
+persistConsent( 'reject_all', payload );
+}
+
+function handleSavePreferences() {
+var payload = buildConsentPayload( false, false );
+persistConsent( 'consent', payload );
+closeModal();
+}
+
+function persistConsent( event, payload ) {
+var consentMode = mapToConsentMode( payload );
+if ( window.fpPrivacyConsent ) {
+window.fpPrivacyConsent.update( consentMode );
+}
+
+if ( typeof window.dataLayer === 'undefined' ) {
+window.dataLayer = [];
+}
+
+window.dataLayer.push( {
+event: 'fp_consent_update',
+consent: consentMode,
+rev: state.revision,
+ts: Date.now(),
+} );
+
+document.dispatchEvent( new CustomEvent( 'fp-consent-change', { detail: { consent: consentMode, event: event, revision: state.revision } } ) );
+
+if ( ! state.preview_mode && rest.url ) {
+window.fetch( rest.url, {
+method: 'POST',
+headers: {
+'Content-Type': 'application/json',
+'X-WP-Nonce': rest.nonce,
+},
+credentials: 'same-origin',
+body: JSON.stringify( {
+event: event,
+states: payload,
+lang: data.options.state ? data.options.state.lang : document.documentElement.lang || 'en',
+} ),
+} ).catch( function () {} );
+}
+
+hideBanner();
+}
+
+function renderCookieDebug() {
+var panel = document.createElement( 'div' );
+panel.className = 'fp-privacy-cookie-debug';
+panel.innerHTML = '<strong>Cookie debug:</strong> ' + document.cookie;
+banner.appendChild( panel );
+}
+})();

--- a/fp-privacy-cookie-policy/assets/js/consent-mode.js
+++ b/fp-privacy-cookie-policy/assets/js/consent-mode.js
@@ -1,0 +1,38 @@
+(function () {
+if ( ! window.fpPrivacyConsent ) {
+window.fpPrivacyConsent = {};
+}
+
+var consent = window.fpPrivacyConsent;
+
+consent.defaults = function () {
+return window.fpPrivacyConsentDefaults || {};
+};
+
+consent.update = function ( states ) {
+if ( typeof window.dataLayer === 'undefined' ) {
+window.dataLayer = [];
+}
+
+var defaults = consent.defaults();
+var payload = {};
+
+for ( var key in defaults ) {
+if ( defaults.hasOwnProperty( key ) ) {
+payload[ key ] = defaults[ key ];
+}
+}
+
+for ( var consentKey in states ) {
+if ( states.hasOwnProperty( consentKey ) ) {
+payload[ consentKey ] = states[ consentKey ];
+}
+}
+
+if ( typeof window.gtag === 'function' ) {
+window.gtag( 'consent', 'update', payload );
+}
+
+return payload;
+};
+})();

--- a/fp-privacy-cookie-policy/bin/qa-checklist.md
+++ b/fp-privacy-cookie-policy/bin/qa-checklist.md
@@ -1,0 +1,50 @@
+# FP Privacy & Cookie Policy – QA Checklist
+
+Use this checklist to verify the 0.1.0 release across single and multisite environments.
+
+## Activation & Provisioning
+- [ ] Activate on a single site; confirm consent table creation, options population, and policy pages per active language.
+- [ ] Network activate on multisite; verify each site registers tables, options, scheduled cleanup, and generated policy pages.
+- [ ] Create a new site via `wpmu_new_blog`; ensure automatic provisioning runs.
+
+## Banner & Modal
+- [ ] Test floating and bar layouts (top/bottom) across languages (e.g., it_IT, en_US).
+- [ ] Verify Accept All, Reject All, and Preferences buttons (including focus management and keyboard interactions).
+- [ ] Confirm preview mode renders the banner for administrators without setting cookies or logging events.
+- [ ] Validate consent revision bump triggers re-display for visitors with prior consent.
+
+## Consent Logging & Analytics
+- [ ] Trigger accept/reject/granular events; ensure entries appear in **Privacy & Cookie → Consent log** with hashed IPs and JSON states.
+- [ ] Use filters (text/event/date) and expand JSON details; confirm pagination works.
+- [ ] Execute CSV export from the admin UI and via WP-CLI (`wp fp-privacy export --file=...`).
+- [ ] Confirm daily cron (`fp_privacy_cleanup`) purges records older than the configured retention.
+
+## dataLayer & Consent Mode
+- [ ] Inspect network/devtools to ensure `gtag('consent','default', ...)` fires on load with default signals.
+- [ ] Change preferences; confirm `gtag('consent','update', ...)`, `dataLayer.push({ event: 'fp_consent_update', ... })`, and `fp-consent-change` CustomEvent payloads.
+
+## Policy Generator
+- [ ] Run detector-based regeneration after enabling/disabling sample integrations (e.g., GA4 script, Meta Pixel, YouTube embed) and review diff output.
+- [ ] Validate generated privacy/cookie policies include controller info, categories, services table, consent mode mapping, and rights sections.
+- [ ] Confirm `fp_privacy_policy_content` / `fp_cookie_policy_content` filters modify the rendered HTML as expected.
+
+## Admin Experience
+- [ ] Adjust palette controls; verify live preview updates and AA contrast checks surface warnings when thresholds fail.
+- [ ] Import/export settings via Tools (JSON) and observe success/error notices.
+- [ ] Review Quick Guide content for shortcodes, blocks, hooks, and legal disclaimer.
+
+## Shortcodes & Blocks
+- [ ] Insert each shortcode (`[fp_privacy_policy]`, `[fp_cookie_policy]`, `[fp_cookie_preferences]`, `[fp_cookie_banner]`) on a page; verify output and conditional asset loading.
+- [ ] Add the four Gutenberg blocks and confirm editor previews plus front-end rendering.
+
+## Integrations & Extensibility
+- [ ] Test REST API endpoints (`/fp-privacy/v1/consent`, `/fp-privacy/v1/consent/summary`) with proper nonces/capabilities.
+- [ ] Execute each WP-CLI command (`status`, `recreate`, `cleanup`, `export`, `settings-export`, `settings-import`, `detect`, `regenerate`).
+- [ ] Validate exporter/eraser callbacks integrate with WordPress personal data tools.
+
+## Accessibility & Performance
+- [ ] Navigate banner/modal entirely via keyboard (Tab/Shift+Tab, Escape to close).
+- [ ] Inspect inline CSS variables to confirm palettes load only when banner assets enqueue.
+- [ ] Ensure no console errors or blocking scripts arise from banner or admin assets.
+
+Document findings per environment and attach logs/exports where relevant.

--- a/fp-privacy-cookie-policy/blocks/cookie-banner/block.json
+++ b/fp-privacy-cookie-policy/blocks/cookie-banner/block.json
@@ -1,0 +1,32 @@
+{
+    "apiVersion": 2,
+    "name": "fp-privacy/cookie-banner",
+    "title": "FP Cookie Banner",
+    "category": "widgets",
+    "icon": "megaphone",
+    "description": "Manually place the cookie banner in content.",
+    "textdomain": "fp-privacy",
+    "editorScript": "fp-privacy-cookie-banner-block-editor",
+    "editorStyle": "fp-privacy-cookie-banner-block-editor-style",
+    "supports": {
+        "html": false
+    },
+    "attributes": {
+        "layoutType": {
+            "type": "string",
+            "default": "floating"
+        },
+        "position": {
+            "type": "string",
+            "default": "bottom"
+        },
+        "lang": {
+            "type": "string",
+            "default": ""
+        },
+        "forceDisplay": {
+            "type": "boolean",
+            "default": false
+        }
+    }
+}

--- a/fp-privacy-cookie-policy/blocks/cookie-banner/edit.js
+++ b/fp-privacy-cookie-policy/blocks/cookie-banner/edit.js
@@ -1,0 +1,383 @@
+(function ( blocks, element, i18n, components, blockEditor ) {
+    var el = element.createElement;
+    var Fragment = element.Fragment;
+    var InspectorControls = blockEditor.InspectorControls;
+    var PanelBody = components.PanelBody;
+    var SelectControl = components.SelectControl;
+    var TextControl = components.TextControl;
+    var ToggleControl = components.ToggleControl;
+    var ComboboxControl = components.ComboboxControl;
+    var Button = components.Button;
+
+    function getLanguages() {
+        var source = window.fpPrivacyBlockData && window.fpPrivacyBlockData.languages;
+        if ( ! source || ! source.length ) {
+            return [];
+        }
+
+        return source
+            .filter( function ( entry ) {
+                return entry && entry.code;
+            } )
+            .map( function ( entry ) {
+                return {
+                    value: entry.code,
+                    label: entry.label || entry.code,
+                };
+            } );
+    }
+
+    function buildLanguageOptions( current ) {
+        var options = [
+            {
+                value: '',
+                label: i18n.__( 'Inherit current locale', 'fp-privacy' ),
+            },
+        ];
+
+        var languages = getLanguages();
+        var hasCurrent = current === '';
+
+        languages.forEach( function ( item ) {
+            options.push( item );
+            if ( item.value === current ) {
+                hasCurrent = true;
+            }
+        } );
+
+        if ( current && ! hasCurrent ) {
+            options.push( { value: current, label: current } );
+        }
+
+        return options;
+    }
+
+    function getLanguageLabel( value ) {
+        if ( ! value ) {
+            return '';
+        }
+
+        var languages = getLanguages();
+
+        for ( var index = 0; index < languages.length; index++ ) {
+            if ( languages[ index ].value === value ) {
+                return languages[ index ].label;
+            }
+        }
+
+        return value;
+    }
+
+    function normalizeLang( value ) {
+        if ( ! value ) {
+            return '';
+        }
+
+        return value.replace( /[^A-Za-z0-9_\-]/g, '' );
+    }
+
+    function getBannerPreviewMap() {
+        var data = window.fpPrivacyBlockData && window.fpPrivacyBlockData.bannerPreview;
+
+        if ( ! data ) {
+            return {};
+        }
+
+        return data;
+    }
+
+    function getBannerPreviewTexts( lang ) {
+        var map = getBannerPreviewMap();
+        var normalized = normalizeLang( lang );
+
+        if ( normalized && map[ normalized ] ) {
+            return map[ normalized ];
+        }
+
+        var keys = Object.keys( map );
+
+        if ( keys.length ) {
+            return map[ keys[ 0 ] ];
+        }
+
+        return null;
+    }
+
+    blocks.registerBlockType( 'fp-privacy/cookie-banner', {
+        title: i18n.__( 'FP Cookie Banner', 'fp-privacy' ),
+        icon: 'megaphone',
+        category: 'widgets',
+        attributes: {
+            layoutType: {
+                type: 'string',
+                default: 'floating'
+            },
+            position: {
+                type: 'string',
+                default: 'bottom'
+            },
+            lang: {
+                type: 'string',
+                default: ''
+            },
+            forceDisplay: {
+                type: 'boolean',
+                default: false
+            }
+        },
+        edit: function ( props ) {
+            var attrs = props.attributes || {};
+            var layoutType = attrs.layoutType || 'floating';
+            var position = attrs.position || 'bottom';
+            var lang = attrs.lang || '';
+            var forceDisplay = !! attrs.forceDisplay;
+            var options = buildLanguageOptions( lang );
+            var hasCombobox = typeof ComboboxControl !== 'undefined';
+            var languageControl;
+            var languages = getLanguages();
+            var hasLanguages = !! languages.length;
+            var previewLangCode = lang ? normalizeLang( lang ) : '';
+            var previewTexts = getBannerPreviewTexts( previewLangCode );
+            var previewTitle = previewTexts && previewTexts.title ? previewTexts.title : i18n.__( 'Sample banner title', 'fp-privacy' );
+            var previewMessage =
+                previewTexts && previewTexts.message
+                    ? previewTexts.message
+                    : i18n.__( 'Update the banner texts from the plugin settings to preview them here.', 'fp-privacy' );
+            var acceptLabel = previewTexts && previewTexts.accept ? previewTexts.accept : i18n.__( 'Accept', 'fp-privacy' );
+            var rejectLabel = previewTexts && previewTexts.reject ? previewTexts.reject : i18n.__( 'Reject', 'fp-privacy' );
+            var preferencesLabel = previewTexts && previewTexts.prefs ? previewTexts.prefs : i18n.__( 'Preferences', 'fp-privacy' );
+            var hasPreviewTexts = !! previewTexts;
+
+            if ( hasCombobox ) {
+                languageControl = el( ComboboxControl, {
+                    label: i18n.__( 'Language', 'fp-privacy' ),
+                    value: lang,
+                    options: options,
+                    onChange: function ( value ) {
+                        var normalized = normalizeLang( value );
+                        props.setAttributes( { lang: normalized } );
+                    },
+                    help: i18n.__( 'Pick one of the configured languages or type a custom code.', 'fp-privacy' ),
+                } );
+            } else {
+                languageControl = el( TextControl, {
+                    label: i18n.__( 'Language code', 'fp-privacy' ),
+                    value: lang,
+                    help: ( function () {
+                        var languages = getLanguages();
+                        if ( ! languages.length ) {
+                            return i18n.__( 'Leave empty to match the current page locale.', 'fp-privacy' );
+                        }
+
+                        var readable = languages
+                            .map( function ( item ) {
+                                return item.label + ' (' + item.value + ')';
+                            } )
+                            .join( ', ' );
+
+                        return (
+                            i18n.__( 'Leave empty to match the current page locale.', 'fp-privacy' ) +
+                            ' ' +
+                            i18n.__( 'Available languages:', 'fp-privacy' ) +
+                            ' ' +
+                            readable
+                        );
+                    } )(),
+                    onChange: function ( value ) {
+                        props.setAttributes( { lang: normalizeLang( value ) } );
+                    },
+                } );
+            }
+
+            var previewClass = [ 'fp-privacy-banner-preview' ];
+
+            if ( layoutType === 'bar' ) {
+                previewClass.push( 'fp-privacy-banner-preview--bar' );
+            } else {
+                previewClass.push( 'fp-privacy-banner-preview--floating' );
+            }
+
+            if ( position === 'top' ) {
+                previewClass.push( 'fp-privacy-banner-preview--top' );
+            } else {
+                previewClass.push( 'fp-privacy-banner-preview--bottom' );
+            }
+
+            var layoutLabel = layoutType === 'bar'
+                ? i18n.__( 'Full-width bar', 'fp-privacy' )
+                : i18n.__( 'Floating panel', 'fp-privacy' );
+            var positionLabel = position === 'top'
+                ? i18n.__( 'Top of the page', 'fp-privacy' )
+                : i18n.__( 'Bottom of the page', 'fp-privacy' );
+            var previewLanguageLabel = previewLangCode
+                ? i18n.sprintf( i18n.__( 'Language: %s', 'fp-privacy' ), getLanguageLabel( previewLangCode ) )
+                : i18n.__( 'Using the current site locale', 'fp-privacy' );
+
+            return el(
+                Fragment,
+                {},
+                el(
+                    InspectorControls,
+                    {},
+                    el(
+                        PanelBody,
+                        {
+                            title: i18n.__( 'Cookie banner settings', 'fp-privacy' ),
+                            initialOpen: true
+                        },
+                        el( SelectControl, {
+                            label: i18n.__( 'Layout', 'fp-privacy' ),
+                            value: layoutType,
+                            options: [
+                                { label: i18n.__( 'Floating panel', 'fp-privacy' ), value: 'floating' },
+                                { label: i18n.__( 'Full-width bar', 'fp-privacy' ), value: 'bar' }
+                            ],
+                            onChange: function ( value ) {
+                                props.setAttributes( { layoutType: value === 'bar' ? 'bar' : 'floating' } );
+                            }
+                        } ),
+                        el( SelectControl, {
+                            label: i18n.__( 'Position', 'fp-privacy' ),
+                            value: position,
+                            options: [
+                                { label: i18n.__( 'Bottom', 'fp-privacy' ), value: 'bottom' },
+                                { label: i18n.__( 'Top', 'fp-privacy' ), value: 'top' }
+                            ],
+                            onChange: function ( value ) {
+                                props.setAttributes( { position: value === 'top' ? 'top' : 'bottom' } );
+                            }
+                        } ),
+                        languageControl,
+                        el( ToggleControl, {
+                            label: i18n.__( 'Always display this banner instance', 'fp-privacy' ),
+                            checked: forceDisplay,
+                            onChange: function ( value ) {
+                                props.setAttributes( { forceDisplay: !! value } );
+                            },
+                            help: i18n.__( 'Force the banner to render even if the visitor has already provided consent.', 'fp-privacy' )
+                        } ),
+                        el( Button, {
+                            variant: 'secondary',
+                            onClick: function () {
+                                props.setAttributes( {
+                                    layoutType: 'floating',
+                                    position: 'bottom',
+                                    lang: '',
+                                    forceDisplay: false
+                                } );
+                            },
+                            className: 'fp-privacy-banner-preview__reset'
+                        }, i18n.__( 'Reset to plugin defaults', 'fp-privacy' ) )
+                    )
+                ),
+                el(
+                    'div',
+                    { className: previewClass.join( ' ' ) },
+                    el( 'div', { className: 'fp-privacy-banner-preview__header' }, i18n.__( 'Cookie banner preview', 'fp-privacy' ) ),
+                    el(
+                        'p',
+                        { className: 'fp-privacy-banner-preview__description' },
+                        i18n.__(
+                            'Use the inspector controls to review layout, position, and language overrides before publishing the banner.',
+                            'fp-privacy'
+                        )
+                    ),
+                    el(
+                        'div',
+                        { className: 'fp-privacy-banner-preview__content' },
+                        el( 'p', { className: 'fp-privacy-banner-preview__title' }, previewTitle ),
+                        el( 'p', { className: 'fp-privacy-banner-preview__message' }, previewMessage )
+                    ),
+                    ! hasPreviewTexts
+                        ? el(
+                              'div',
+                              { className: 'fp-privacy-banner-preview__notice' },
+                              i18n.__(
+                                  'Save the plugin settings after editing banner content to preview the actual copy for each language.',
+                                  'fp-privacy'
+                              )
+                          )
+                        : null,
+                    el(
+                        'div',
+                        { className: 'fp-privacy-banner-preview__chips' },
+                        el( 'span', { className: 'fp-privacy-banner-preview__chip' }, layoutLabel ),
+                        el( 'span', { className: 'fp-privacy-banner-preview__chip' }, positionLabel ),
+                        el( 'span', { className: 'fp-privacy-banner-preview__chip fp-privacy-banner-preview__chip--language' }, previewLanguageLabel ),
+                        forceDisplay
+                            ? el(
+                                  'span',
+                                  { className: 'fp-privacy-banner-preview__chip fp-privacy-banner-preview__chip--warning' },
+                                  i18n.__( 'Forced display enabled', 'fp-privacy' )
+                              )
+                            : null
+                    ),
+                    hasLanguages
+                        ? null
+                        : el(
+                              'div',
+                              { className: 'fp-privacy-banner-preview__notice' },
+                              i18n.__(
+                                  'No additional languages are configured yet. Add them from the plugin settings to customise the banner per locale.',
+                                  'fp-privacy'
+                              )
+                          ),
+                    forceDisplay
+                        ? el(
+                              'div',
+                              { className: 'fp-privacy-banner-preview__alert' },
+                              i18n.__(
+                                  'Forced display bypasses the automatic hide behaviour. Confirm the banner placement remains accessible across devices.',
+                                  'fp-privacy'
+                              )
+                          )
+                        : null,
+                    el(
+                        'div',
+                        { className: 'fp-privacy-banner-preview__buttons' },
+                        el( 'span', { className: 'fp-privacy-banner-preview__button is-primary' }, acceptLabel ),
+                        el( 'span', { className: 'fp-privacy-banner-preview__button' }, rejectLabel ),
+                        el( 'span', { className: 'fp-privacy-banner-preview__button' }, preferencesLabel )
+                    ),
+                    el(
+                        'ul',
+                        { className: 'fp-privacy-banner-preview__hints' },
+                        el(
+                            'li',
+                            { className: 'fp-privacy-banner-preview__hint' },
+                            i18n.__(
+                                'Floating panels anchor near a corner whereas bars stretch across the viewport edge.',
+                                'fp-privacy'
+                            )
+                        ),
+                        el(
+                            'li',
+                            { className: 'fp-privacy-banner-preview__hint' },
+                            i18n.__(
+                                'Language overrides let you review translated banner texts without switching the editor UI.',
+                                'fp-privacy'
+                            )
+                        ),
+                        el(
+                            'li',
+                            { className: 'fp-privacy-banner-preview__hint' },
+                            i18n.__(
+                                'Forced display keeps the banner visible when manually embedding it alongside other content.',
+                                'fp-privacy'
+                            )
+                        )
+                    )
+                )
+            );
+        },
+        save: function () {
+            return null;
+        }
+    } );
+})(
+    window.wp.blocks,
+    window.wp.element,
+    window.wp.i18n,
+    window.wp.components,
+    window.wp.blockEditor || window.wp.editor
+);

--- a/fp-privacy-cookie-policy/blocks/cookie-banner/style.css
+++ b/fp-privacy-cookie-policy/blocks/cookie-banner/style.css
@@ -1,0 +1,136 @@
+.fp-privacy-banner-preview {
+    background: #f9fafb;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    padding: 16px;
+    color: #1f2937;
+    line-height: 1.5;
+    font-size: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-width: 360px;
+}
+
+.fp-privacy-banner-preview--bar {
+    max-width: none;
+    width: 100%;
+}
+
+.fp-privacy-banner-preview__header {
+    font-weight: 600;
+    color: #111827;
+    margin: 0;
+}
+
+.fp-privacy-banner-preview__description {
+    margin: 0;
+    color: #4b5563;
+}
+
+.fp-privacy-banner-preview__content {
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+    background: #ffffff;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.fp-privacy-banner-preview__title {
+    margin: 0;
+    font-weight: 600;
+    color: #111827;
+    font-size: 14px;
+}
+
+.fp-privacy-banner-preview__message {
+    margin: 0;
+    color: #374151;
+    font-size: 13px;
+}
+
+.fp-privacy-banner-preview__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.fp-privacy-banner-preview__chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: #e5e7eb;
+    color: #1f2937;
+    font-size: 12px;
+    line-height: 1;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.fp-privacy-banner-preview__chip--language {
+    background: #dbeafe;
+    color: #1d4ed8;
+}
+
+.fp-privacy-banner-preview__chip--warning {
+    background: #fef3c7;
+    color: #92400e;
+}
+
+.fp-privacy-banner-preview__notice {
+    background: #fef3c7;
+    border: 1px solid #f59e0b;
+    border-radius: 4px;
+    padding: 8px 12px;
+    color: #92400e;
+}
+
+.fp-privacy-banner-preview__reset {
+    margin-top: 12px;
+}
+
+.fp-privacy-banner-preview__alert {
+    background: #fee2e2;
+    border: 1px solid #f87171;
+    border-radius: 4px;
+    padding: 8px 12px;
+    color: #991b1b;
+    font-size: 13px;
+}
+
+.fp-privacy-banner-preview__buttons {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.fp-privacy-banner-preview__button {
+    border-radius: 999px;
+    padding: 6px 16px;
+    background: #e5e7eb;
+    color: #111827;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.fp-privacy-banner-preview__button.is-primary {
+    background: #2563eb;
+    color: #ffffff;
+}
+
+.fp-privacy-banner-preview__hints {
+    margin: 0;
+    padding-left: 18px;
+    color: #374151;
+}
+
+.fp-privacy-banner-preview__hint {
+    margin-bottom: 6px;
+}
+
+.fp-privacy-banner-preview__hint:last-child {
+    margin-bottom: 0;
+}

--- a/fp-privacy-cookie-policy/blocks/cookie-policy/block.json
+++ b/fp-privacy-cookie-policy/blocks/cookie-policy/block.json
@@ -1,0 +1,20 @@
+{
+    "apiVersion": 2,
+    "name": "fp-privacy/cookie-policy",
+    "title": "FP Cookie Policy",
+    "category": "widgets",
+    "icon": "list-view",
+    "description": "Displays the generated cookie policy.",
+    "textdomain": "fp-privacy",
+    "attributes": {
+        "lang": {
+            "type": "string",
+            "default": ""
+        }
+    },
+    "editorScript": "fp-privacy-cookie-policy-block-editor",
+    "editorStyle": "fp-privacy-cookie-policy-block-editor-style",
+    "supports": {
+        "html": false
+    }
+}

--- a/fp-privacy-cookie-policy/blocks/cookie-policy/edit.js
+++ b/fp-privacy-cookie-policy/blocks/cookie-policy/edit.js
@@ -1,0 +1,196 @@
+(function ( blocks, element, i18n, components, blockEditor ) {
+    var el = element.createElement;
+    var Fragment = element.Fragment;
+    var InspectorControls = blockEditor.InspectorControls;
+    var PanelBody = components.PanelBody;
+    var TextControl = components.TextControl;
+    var ComboboxControl = components.ComboboxControl;
+
+    function getLanguages() {
+        var source = window.fpPrivacyBlockData && window.fpPrivacyBlockData.languages;
+        if ( ! source || ! source.length ) {
+            return [];
+        }
+
+        return source
+            .filter( function ( entry ) {
+                return entry && entry.code;
+            } )
+            .map( function ( entry ) {
+                return {
+                    value: entry.code,
+                    label: entry.label || entry.code,
+                };
+            } );
+    }
+
+    function buildLanguageOptions( current ) {
+        var options = [
+            {
+                value: '',
+                label: i18n.__( 'Inherit current locale', 'fp-privacy' ),
+            },
+        ];
+
+        var languages = getLanguages();
+        var hasCurrent = current === '';
+
+        languages.forEach( function ( item ) {
+            options.push( item );
+            if ( item.value === current ) {
+                hasCurrent = true;
+            }
+        } );
+
+        if ( current && ! hasCurrent ) {
+            options.push( { value: current, label: current } );
+        }
+
+        return options;
+    }
+
+    function normalizeLang( value ) {
+        if ( ! value ) {
+            return '';
+        }
+
+        return value.replace( /[^A-Za-z0-9_\-]/g, '' );
+    }
+
+    blocks.registerBlockType( 'fp-privacy/cookie-policy', {
+        title: i18n.__( 'FP Cookie Policy', 'fp-privacy' ),
+        icon: 'list-view',
+        category: 'widgets',
+        edit: function ( props ) {
+            var lang = props.attributes.lang || '';
+            var options = buildLanguageOptions( lang );
+            var hasCombobox = typeof ComboboxControl !== 'undefined';
+            var languageControl;
+            var languages = getLanguages();
+            var hasLanguages = !! languages.length;
+            var previewLanguageLabel;
+
+            if ( hasCombobox ) {
+                languageControl = el( ComboboxControl, {
+                    label: i18n.__( 'Language', 'fp-privacy' ),
+                    value: lang,
+                    options: options,
+                    onChange: function ( value ) {
+                        var normalized = normalizeLang( value );
+                        props.setAttributes( { lang: normalized } );
+                    },
+                    help: i18n.__( 'Pick one of the configured languages or type a custom code.', 'fp-privacy' ),
+                } );
+            } else {
+                languageControl = el( TextControl, {
+                    label: i18n.__( 'Language code', 'fp-privacy' ),
+                    value: lang,
+                    onChange: function ( value ) {
+                        props.setAttributes( { lang: normalizeLang( value ) } );
+                    },
+                    help: ( function () {
+                        var languages = getLanguages();
+                        if ( ! languages.length ) {
+                            return i18n.__( 'Leave empty to use the current site locale.', 'fp-privacy' );
+                        }
+
+                        var readable = languages
+                            .map( function ( item ) {
+                                return item.label + ' (' + item.value + ')';
+                            } )
+                            .join( ', ' );
+
+                        return (
+                            i18n.__( 'Leave empty to use the current site locale.', 'fp-privacy' ) +
+                            ' ' +
+                            i18n.__( 'Available languages:', 'fp-privacy' ) +
+                            ' ' +
+                            readable
+                        );
+                    } )(),
+                } );
+            }
+
+            previewLanguageLabel = lang
+                ? i18n.sprintf( i18n.__( 'Language: %s', 'fp-privacy' ), lang )
+                : i18n.__( 'Using the current site locale', 'fp-privacy' );
+
+            return el(
+                Fragment,
+                {},
+                el(
+                    InspectorControls,
+                    {},
+                    el(
+                        PanelBody,
+                        {
+                            title: i18n.__( 'Cookie policy settings', 'fp-privacy' ),
+                            initialOpen: true,
+                        },
+                        languageControl
+                    )
+                ),
+                el(
+                    'div',
+                    { className: 'fp-privacy-policy-preview' },
+                    el(
+                        'div',
+                        { className: 'fp-privacy-policy-preview__header' },
+                        i18n.__( 'Cookie policy preview', 'fp-privacy' )
+                    ),
+                    el(
+                        'p',
+                        { className: 'fp-privacy-policy-preview__description' },
+                        i18n.__(
+                            'This block prints the generated cookie policy on the front-end. Configure the language to review locale-specific content while editing.',
+                            'fp-privacy'
+                        )
+                    ),
+                    el(
+                        'div',
+                        { className: 'fp-privacy-policy-preview__language' },
+                        previewLanguageLabel
+                    ),
+                    hasLanguages
+                        ? null
+                        : el(
+                              'div',
+                              { className: 'fp-privacy-policy-preview__notice' },
+                              i18n.__(
+                                  'No additional languages are configured yet. Add them from the plugin settings to manage locale-specific policies.',
+                                  'fp-privacy'
+                              )
+                          ),
+                    el(
+                        'ul',
+                        { className: 'fp-privacy-policy-preview__sections' },
+                        el(
+                            'li',
+                            { className: 'fp-privacy-policy-preview__section' },
+                            i18n.__( 'Service overview, legal bases, and retention for each category.', 'fp-privacy' )
+                        ),
+                        el(
+                            'li',
+                            { className: 'fp-privacy-policy-preview__section' },
+                            i18n.__( 'Cookie tables are rendered automatically from detected services.', 'fp-privacy' )
+                        ),
+                        el(
+                            'li',
+                            { className: 'fp-privacy-policy-preview__section' },
+                            i18n.__( 'Visitors see language-specific contacts and owner details.', 'fp-privacy' )
+                        )
+                    )
+                )
+            );
+        },
+        save: function () {
+            return null;
+        },
+    } );
+})(
+    window.wp.blocks,
+    window.wp.element,
+    window.wp.i18n,
+    window.wp.components,
+    window.wp.blockEditor || window.wp.editor
+);

--- a/fp-privacy-cookie-policy/blocks/cookie-policy/style.css
+++ b/fp-privacy-cookie-policy/blocks/cookie-policy/style.css
@@ -1,0 +1,57 @@
+.fp-privacy-policy-preview {
+    background: #f9fafb;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    padding: 16px;
+    color: #1f2937;
+    line-height: 1.5;
+    font-size: 14px;
+}
+
+.fp-privacy-policy-preview__header {
+    font-weight: 600;
+    margin-bottom: 4px;
+    color: #111827;
+}
+
+.fp-privacy-policy-preview__description {
+    margin: 0 0 12px;
+    color: #4b5563;
+}
+
+.fp-privacy-policy-preview__language {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: #e0f2fe;
+    color: #1d4ed8;
+    margin-bottom: 12px;
+}
+
+.fp-privacy-policy-preview__notice {
+    background: #fef3c7;
+    border: 1px solid #f59e0b;
+    border-radius: 4px;
+    padding: 8px 12px;
+    margin-bottom: 12px;
+    color: #92400e;
+}
+
+.fp-privacy-policy-preview__sections {
+    margin: 0;
+    padding-left: 18px;
+    color: #374151;
+}
+
+.fp-privacy-policy-preview__section {
+    margin-bottom: 6px;
+}
+
+.fp-privacy-policy-preview__section:last-child {
+    margin-bottom: 0;
+}

--- a/fp-privacy-cookie-policy/blocks/cookie-preferences/block.json
+++ b/fp-privacy-cookie-policy/blocks/cookie-preferences/block.json
@@ -1,0 +1,28 @@
+{
+    "apiVersion": 2,
+    "name": "fp-privacy/cookie-preferences",
+    "title": "FP Cookie Preferences",
+    "category": "widgets",
+    "icon": "admin-settings",
+    "description": "Displays a button to open the cookie preferences modal.",
+    "textdomain": "fp-privacy",
+    "editorScript": "fp-privacy-cookie-preferences-block-editor",
+    "editorStyle": "fp-privacy-cookie-preferences-block-editor-style",
+    "attributes": {
+        "label": {
+            "type": "string",
+            "default": ""
+        },
+        "description": {
+            "type": "string",
+            "default": ""
+        },
+        "lang": {
+            "type": "string",
+            "default": ""
+        }
+    },
+    "supports": {
+        "html": false
+    }
+}

--- a/fp-privacy-cookie-policy/blocks/cookie-preferences/edit.js
+++ b/fp-privacy-cookie-policy/blocks/cookie-preferences/edit.js
@@ -1,0 +1,253 @@
+(function ( blocks, element, i18n, components, blockEditor ) {
+    var el = element.createElement;
+    var Fragment = element.Fragment;
+    var InspectorControls = blockEditor.InspectorControls;
+    var PanelBody = components.PanelBody;
+    var TextControl = components.TextControl;
+    var TextareaControl = components.TextareaControl;
+    var ComboboxControl = components.ComboboxControl;
+
+    var DEFAULT_LABEL = i18n.__( 'Manage cookie preferences', 'fp-privacy' );
+    var DEFAULT_DESCRIPTION = i18n.__(
+        'Opens the cookie preferences modal so visitors can review or update their consent.',
+        'fp-privacy'
+    );
+
+    function getLanguages() {
+        var source = window.fpPrivacyBlockData && window.fpPrivacyBlockData.languages;
+        if ( ! source || ! source.length ) {
+            return [];
+        }
+
+        return source
+            .filter( function ( entry ) {
+                return entry && entry.code;
+            } )
+            .map( function ( entry ) {
+                return {
+                    value: entry.code,
+                    label: entry.label || entry.code,
+                };
+            } );
+    }
+
+    function buildLanguageOptions( current ) {
+        var options = [
+            {
+                value: '',
+                label: i18n.__( 'Inherit current locale', 'fp-privacy' ),
+            },
+        ];
+
+        var languages = getLanguages();
+        var hasCurrent = current === '';
+
+        languages.forEach( function ( item ) {
+            options.push( item );
+            if ( item.value === current ) {
+                hasCurrent = true;
+            }
+        } );
+
+        if ( current && ! hasCurrent ) {
+            options.push( { value: current, label: current } );
+        }
+
+        return options;
+    }
+
+    function normalizeLang( value ) {
+        if ( ! value ) {
+            return '';
+        }
+
+        return value.replace( /[^A-Za-z0-9_\-]/g, '' );
+    }
+
+    blocks.registerBlockType( 'fp-privacy/cookie-preferences', {
+        title: i18n.__( 'FP Cookie Preferences', 'fp-privacy' ),
+        icon: 'admin-settings',
+        category: 'widgets',
+        attributes: {
+            label: {
+                type: 'string',
+                default: ''
+            },
+            description: {
+                type: 'string',
+                default: ''
+            },
+            lang: {
+                type: 'string',
+                default: ''
+            }
+        },
+        edit: function ( props ) {
+            var attrs = props.attributes || {};
+            var label = attrs.label || '';
+            var description = attrs.description || '';
+            var lang = attrs.lang || '';
+            var options = buildLanguageOptions( lang );
+            var hasCombobox = typeof ComboboxControl !== 'undefined';
+            var languageControl;
+            var languages = getLanguages();
+            var hasLanguages = !! languages.length;
+
+            if ( hasCombobox ) {
+                languageControl = el( ComboboxControl, {
+                    label: i18n.__( 'Language', 'fp-privacy' ),
+                    value: lang,
+                    options: options,
+                    onChange: function ( value ) {
+                        var normalized = normalizeLang( value );
+                        props.setAttributes( { lang: normalized } );
+                    },
+                    help: i18n.__( 'Pick one of the configured languages or type a custom code.', 'fp-privacy' ),
+                } );
+            } else {
+                languageControl = el( TextControl, {
+                    label: i18n.__( 'Language code', 'fp-privacy' ),
+                    value: lang,
+                    onChange: function ( value ) {
+                        props.setAttributes( { lang: normalizeLang( value ) } );
+                    },
+                    help: ( function () {
+                        var languages = getLanguages();
+                        if ( ! languages.length ) {
+                            return i18n.__( 'Leave empty to use the current site locale.', 'fp-privacy' );
+                        }
+
+                        var readable = languages
+                            .map( function ( item ) {
+                                return item.label + ' (' + item.value + ')';
+                            } )
+                            .join( ', ' );
+
+                        return (
+                            i18n.__( 'Leave empty to use the current site locale.', 'fp-privacy' ) +
+                            ' ' +
+                            i18n.__( 'Available languages:', 'fp-privacy' ) +
+                            ' ' +
+                            readable
+                        );
+                    } )(),
+                } );
+            }
+
+            var previewLabel = label || DEFAULT_LABEL;
+            var previewDescription = description || DEFAULT_DESCRIPTION;
+            var previewLanguageLabel = lang
+                ? i18n.sprintf( i18n.__( 'Language: %s', 'fp-privacy' ), lang )
+                : i18n.__( 'Using the current site locale', 'fp-privacy' );
+
+            return el(
+                Fragment,
+                {},
+                el(
+                    InspectorControls,
+                    {},
+                    el(
+                        PanelBody,
+                        {
+                            title: i18n.__( 'Cookie preferences settings', 'fp-privacy' ),
+                            initialOpen: true
+                        },
+                        el( TextControl, {
+                            label: i18n.__( 'Button label', 'fp-privacy' ),
+                            value: label,
+                            placeholder: DEFAULT_LABEL,
+                            onChange: function ( value ) {
+                                props.setAttributes( { label: value } );
+                            }
+                        } ),
+                        el( TextareaControl, {
+                            label: i18n.__( 'Accessibility description', 'fp-privacy' ),
+                            value: description,
+                            placeholder: DEFAULT_DESCRIPTION,
+                            help: i18n.__( 'Announced by assistive technologies when the button receives focus.', 'fp-privacy' ),
+                            onChange: function ( value ) {
+                                props.setAttributes( { description: value } );
+                            }
+                        } ),
+                        languageControl
+                    )
+                ),
+                el(
+                    'div',
+                    { className: 'fp-privacy-preferences-preview' },
+                    el(
+                        'div',
+                        { className: 'fp-privacy-preferences-preview__header' },
+                        i18n.__( 'Cookie preferences preview', 'fp-privacy' )
+                    ),
+                    el(
+                        'p',
+                        { className: 'fp-privacy-preferences-preview__description' },
+                        i18n.__(
+                            'The block renders a button that opens the cookie preferences modal so visitors can change their choices.',
+                            'fp-privacy'
+                        )
+                    ),
+                    el( 'div', { className: 'fp-privacy-preferences-preview__language' }, previewLanguageLabel ),
+                    hasLanguages
+                        ? null
+                        : el(
+                              'div',
+                              { className: 'fp-privacy-preferences-preview__notice' },
+                              i18n.__(
+                                  'No additional languages are configured yet. Add them from the plugin settings to customize button text per locale.',
+                                  'fp-privacy'
+                              )
+                          ),
+                    el(
+                        'div',
+                        { className: 'fp-privacy-preferences-preview__button' },
+                        previewLabel
+                    ),
+                    el(
+                        'p',
+                        { className: 'fp-privacy-preferences-preview__assistive' },
+                        previewDescription
+                    ),
+                    el(
+                        'ul',
+                        { className: 'fp-privacy-preferences-preview__hints' },
+                        el(
+                            'li',
+                            { className: 'fp-privacy-preferences-preview__hint' },
+                            i18n.__(
+                                'On the front-end the button receives focus styles that meet AA contrast requirements.',
+                                'fp-privacy'
+                            )
+                        ),
+                        el(
+                            'li',
+                            { className: 'fp-privacy-preferences-preview__hint' },
+                            i18n.__(
+                                'Screen readers announce the accessibility description before opening the modal.',
+                                'fp-privacy'
+                            )
+                        ),
+                        el(
+                            'li',
+                            { className: 'fp-privacy-preferences-preview__hint' },
+                            i18n.__(
+                                'The modal displays a summary of the last recorded consent for additional context.',
+                                'fp-privacy'
+                            )
+                        )
+                    )
+                )
+            );
+        },
+        save: function () {
+            return null;
+        }
+    } );
+})(
+    window.wp.blocks,
+    window.wp.element,
+    window.wp.i18n,
+    window.wp.components,
+    window.wp.blockEditor || window.wp.editor
+);

--- a/fp-privacy-cookie-policy/blocks/cookie-preferences/style.css
+++ b/fp-privacy-cookie-policy/blocks/cookie-preferences/style.css
@@ -1,0 +1,76 @@
+.fp-privacy-preferences-preview {
+    background: #f9fafb;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    padding: 16px;
+    color: #1f2937;
+    line-height: 1.5;
+    font-size: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.fp-privacy-preferences-preview__header {
+    font-weight: 600;
+    color: #111827;
+    margin: 0;
+}
+
+.fp-privacy-preferences-preview__description {
+    margin: 0;
+    color: #4b5563;
+}
+
+.fp-privacy-preferences-preview__language {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: #e0f2fe;
+    color: #1d4ed8;
+}
+
+.fp-privacy-preferences-preview__notice {
+    background: #fef3c7;
+    border: 1px solid #f59e0b;
+    border-radius: 4px;
+    padding: 8px 12px;
+    color: #92400e;
+}
+
+.fp-privacy-preferences-preview__button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6px 18px;
+    border-radius: 999px;
+    background: #2563eb;
+    color: #ffffff;
+    font-weight: 600;
+    align-self: flex-start;
+}
+
+.fp-privacy-preferences-preview__assistive {
+    margin: 0;
+    font-size: 12px;
+    color: #6b7280;
+}
+
+.fp-privacy-preferences-preview__hints {
+    margin: 0;
+    padding-left: 18px;
+    color: #374151;
+}
+
+.fp-privacy-preferences-preview__hint {
+    margin-bottom: 6px;
+}
+
+.fp-privacy-preferences-preview__hint:last-child {
+    margin-bottom: 0;
+}

--- a/fp-privacy-cookie-policy/blocks/privacy-policy/block.json
+++ b/fp-privacy-cookie-policy/blocks/privacy-policy/block.json
@@ -1,0 +1,20 @@
+{
+    "apiVersion": 2,
+    "name": "fp-privacy/privacy-policy",
+    "title": "FP Privacy Policy",
+    "category": "widgets",
+    "icon": "shield",
+    "description": "Displays the generated privacy policy.",
+    "textdomain": "fp-privacy",
+    "attributes": {
+        "lang": {
+            "type": "string",
+            "default": ""
+        }
+    },
+    "editorScript": "fp-privacy-privacy-policy-block-editor",
+    "editorStyle": "fp-privacy-privacy-policy-block-editor-style",
+    "supports": {
+        "html": false
+    }
+}

--- a/fp-privacy-cookie-policy/blocks/privacy-policy/edit.js
+++ b/fp-privacy-cookie-policy/blocks/privacy-policy/edit.js
@@ -1,0 +1,188 @@
+(function ( blocks, element, i18n, components, blockEditor ) {
+    var el = element.createElement;
+    var Fragment = element.Fragment;
+    var InspectorControls = blockEditor.InspectorControls;
+    var PanelBody = components.PanelBody;
+    var TextControl = components.TextControl;
+    var ComboboxControl = components.ComboboxControl;
+
+    function getLanguages() {
+        var source = window.fpPrivacyBlockData && window.fpPrivacyBlockData.languages;
+        if ( ! source || ! source.length ) {
+            return [];
+        }
+
+        return source
+            .filter( function ( entry ) {
+                return entry && entry.code;
+            } )
+            .map( function ( entry ) {
+                return {
+                    value: entry.code,
+                    label: entry.label || entry.code,
+                };
+            } );
+    }
+
+    function buildLanguageOptions( current ) {
+        var options = [
+            {
+                value: '',
+                label: i18n.__( 'Inherit current locale', 'fp-privacy' ),
+            },
+        ];
+
+        var languages = getLanguages();
+        var hasCurrent = current === '';
+
+        languages.forEach( function ( item ) {
+            options.push( item );
+            if ( item.value === current ) {
+                hasCurrent = true;
+            }
+        } );
+
+        if ( current && ! hasCurrent ) {
+            options.push( { value: current, label: current } );
+        }
+
+        return options;
+    }
+
+    function normalizeLang( value ) {
+        if ( ! value ) {
+            return '';
+        }
+
+        return value.replace( /[^A-Za-z0-9_\-]/g, '' );
+    }
+
+    blocks.registerBlockType( 'fp-privacy/privacy-policy', {
+        title: i18n.__( 'FP Privacy Policy', 'fp-privacy' ),
+        icon: 'shield',
+        category: 'widgets',
+        edit: function ( props ) {
+            var lang = props.attributes.lang || '';
+            var options = buildLanguageOptions( lang );
+            var hasCombobox = typeof ComboboxControl !== 'undefined';
+            var languageControl;
+            var languages = getLanguages();
+            var hasLanguages = !! languages.length;
+            var previewLanguageLabel = lang
+                ? i18n.sprintf( i18n.__( 'Language: %s', 'fp-privacy' ), lang )
+                : i18n.__( 'Using the current site locale', 'fp-privacy' );
+
+            if ( hasCombobox ) {
+                languageControl = el( ComboboxControl, {
+                    label: i18n.__( 'Language', 'fp-privacy' ),
+                    value: lang,
+                    options: options,
+                    onChange: function ( value ) {
+                        props.setAttributes( { lang: normalizeLang( value ) } );
+                    },
+                    help: i18n.__( 'Pick one of the configured languages or type a custom code.', 'fp-privacy' ),
+                } );
+            } else {
+                languageControl = el( TextControl, {
+                    label: i18n.__( 'Language code', 'fp-privacy' ),
+                    value: lang,
+                    onChange: function ( value ) {
+                        props.setAttributes( { lang: normalizeLang( value ) } );
+                    },
+                    help: ( function () {
+                        if ( ! languages.length ) {
+                            return i18n.__( 'Leave empty to use the current site locale.', 'fp-privacy' );
+                        }
+
+                        var readable = languages
+                            .map( function ( item ) {
+                                return item.label + ' (' + item.value + ')';
+                            } )
+                            .join( ', ' );
+
+                        return (
+                            i18n.__( 'Leave empty to use the current site locale.', 'fp-privacy' ) +
+                            ' ' +
+                            i18n.__( 'Available languages:', 'fp-privacy' ) +
+                            ' ' +
+                            readable
+                        );
+                    } )(),
+                } );
+            }
+
+            return el(
+                Fragment,
+                {},
+                el(
+                    InspectorControls,
+                    {},
+                    el(
+                        PanelBody,
+                        {
+                            title: i18n.__( 'Privacy policy settings', 'fp-privacy' ),
+                            initialOpen: true,
+                        },
+                        languageControl
+                    )
+                ),
+                el(
+                    'div',
+                    { className: 'fp-privacy-policy-preview' },
+                    el(
+                        'div',
+                        { className: 'fp-privacy-policy-preview__header' },
+                        i18n.__( 'Privacy policy preview', 'fp-privacy' )
+                    ),
+                    el(
+                        'p',
+                        { className: 'fp-privacy-policy-preview__description' },
+                        i18n.__(
+                            'This block prints the generated privacy policy on the front-end. Configure the language to review locale-specific content while editing.',
+                            'fp-privacy'
+                        )
+                    ),
+                    el( 'div', { className: 'fp-privacy-policy-preview__language' }, previewLanguageLabel ),
+                    hasLanguages
+                        ? null
+                        : el(
+                              'div',
+                              { className: 'fp-privacy-policy-preview__notice' },
+                              i18n.__(
+                                  'No additional languages are configured yet. Add them from the plugin settings to manage locale-specific policies.',
+                                  'fp-privacy'
+                              )
+                          ),
+                    el(
+                        'ul',
+                        { className: 'fp-privacy-policy-preview__sections' },
+                        el(
+                            'li',
+                            { className: 'fp-privacy-policy-preview__section' },
+                            i18n.__( 'Owner details, contact references, and data subject rights.', 'fp-privacy' )
+                        ),
+                        el(
+                            'li',
+                            { className: 'fp-privacy-policy-preview__section' },
+                            i18n.__( 'Legal bases and processing purposes grouped by service categories.', 'fp-privacy' )
+                        ),
+                        el(
+                            'li',
+                            { className: 'fp-privacy-policy-preview__section' },
+                            i18n.__( 'Automatic updates include detected services and consent revision notes.', 'fp-privacy' )
+                        )
+                    )
+                )
+            );
+        },
+        save: function () {
+            return null;
+        }
+    } );
+})(
+    window.wp.blocks,
+    window.wp.element,
+    window.wp.i18n,
+    window.wp.components,
+    window.wp.blockEditor || window.wp.editor
+);

--- a/fp-privacy-cookie-policy/blocks/privacy-policy/style.css
+++ b/fp-privacy-cookie-policy/blocks/privacy-policy/style.css
@@ -1,0 +1,57 @@
+.fp-privacy-policy-preview {
+    background: #f9fafb;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    padding: 16px;
+    color: #1f2937;
+    line-height: 1.5;
+    font-size: 14px;
+}
+
+.fp-privacy-policy-preview__header {
+    font-weight: 600;
+    margin-bottom: 4px;
+    color: #111827;
+}
+
+.fp-privacy-policy-preview__description {
+    margin: 0 0 12px;
+    color: #4b5563;
+}
+
+.fp-privacy-policy-preview__language {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: #e0f2fe;
+    color: #1d4ed8;
+    margin-bottom: 12px;
+}
+
+.fp-privacy-policy-preview__notice {
+    background: #fef3c7;
+    border: 1px solid #f59e0b;
+    border-radius: 4px;
+    padding: 8px 12px;
+    margin-bottom: 12px;
+    color: #92400e;
+}
+
+.fp-privacy-policy-preview__sections {
+    margin: 0;
+    padding-left: 18px;
+    color: #374151;
+}
+
+.fp-privacy-policy-preview__section {
+    margin-bottom: 6px;
+}
+
+.fp-privacy-policy-preview__section:last-child {
+    margin-bottom: 0;
+}

--- a/fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
+++ b/fp-privacy-cookie-policy/fp-privacy-cookie-policy.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Plugin Name: FP Privacy and Cookie Policy
+ * Description: Gestione privacy/cookie policy, banner e consenso (GDPR) + Google Consent Mode v2.
+ * Version: 0.1.0
+ * Author: Francesco Passeri
+ * Author URI: https://francescopasseri.com
+ * Text Domain: fp-privacy
+ * Domain Path: /languages
+ *
+ * @package FP\Privacy
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+
+define( 'FP_PRIVACY_PLUGIN_FILE', __FILE__ );
+
+define( 'FP_PRIVACY_PLUGIN_VERSION', '0.1.0' );
+
+define( 'FP_PRIVACY_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+
+define( 'FP_PRIVACY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+
+define( 'FP_PRIVACY_IP_SALT', 'fp-privacy-cookie-policy-salt' );
+spl_autoload_register(
+function ( $class ) {
+if ( 0 !== strpos( $class, 'FP\\\\Privacy\\\\' ) ) {
+return;
+}
+
+$relative = str_replace( 'FP\\\\Privacy\\\\', '', $class );
+$relative = str_replace( '\\\\', DIRECTORY_SEPARATOR, $relative );
+$path     = FP_PRIVACY_PLUGIN_PATH . 'src/' . $relative . '.php';
+
+if ( file_exists( $path ) ) {
+require_once $path;
+}
+}
+);
+
+if ( ! class_exists( '\\FP\\Privacy\\Plugin' ) ) {
+return;
+}
+
+register_activation_hook( __FILE__, array( '\\FP\\Privacy\\Plugin', 'activate' ) );
+register_deactivation_hook( __FILE__, array( '\\FP\\Privacy\\Plugin', 'deactivate' ) );
+
+add_action(
+    'plugins_loaded',
+    static function () {
+        \FP\Privacy\Plugin::instance()->boot();
+    }
+);
+
+add_action(
+    'wpmu_new_blog',
+    static function ( $blog_id ) {
+        if ( ! is_multisite() ) {
+            return;
+        }
+
+        $plugin = \FP\Privacy\Plugin::instance();
+        $plugin->provision_new_site( (int) $blog_id );
+    }
+);

--- a/fp-privacy-cookie-policy/inc/functions-compat.php
+++ b/fp-privacy-cookie-policy/inc/functions-compat.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Compatibility helpers.
+ *
+ * @package FP\Privacy
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+
+if ( ! function_exists( 'fp_privacy_array_get' ) ) {
+/**
+ * Safely get array value.
+ *
+ * @param array  $array   Source array.
+ * @param string $key     Key.
+ * @param mixed  $default Default.
+ *
+ * @return mixed
+ */
+function fp_privacy_array_get( $array, $key, $default = null ) {
+return isset( $array[ $key ] ) ? $array[ $key ] : $default;
+}
+}

--- a/fp-privacy-cookie-policy/languages/fp-privacy-en_US.po
+++ b/fp-privacy-cookie-policy/languages/fp-privacy-en_US.po
@@ -1,0 +1,980 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: FP Privacy and Cookie Policy 0.1.0\n"
+"Report-Msgid-Bugs-To: https://francescopasseri.com\n"
+"POT-Creation-Date: 2025-02-14 00:00+0000\n"
+"PO-Revision-Date: 2025-02-14 00:00+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: xgettext\n"
+"X-Domain: fp-privacy\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: templates/cookie-policy.php:15
+msgid "About cookies"
+msgstr "About cookies"
+
+#: templates/cookie-policy.php:16
+msgid ""
+"Cookies are small text files stored on your device. They allow us to "
+"remember your preferences, ensure the website works properly and measure "
+"performance. Some cookies are strictly necessary while others require your "
+"consent."
+msgstr ""
+"Cookies are small text files stored on your device. They allow us to "
+"remember your preferences, ensure the website works properly and measure "
+"performance. Some cookies are strictly necessary while others require your "
+"consent."
+
+#: templates/cookie-policy.php:18
+msgid "How we use cookies"
+msgstr "How we use cookies"
+
+#: templates/cookie-policy.php:19
+msgid ""
+"We group cookies into categories so you can tailor your experience. You can "
+"update your preferences at any time using the cookie preferences button."
+msgstr ""
+"We group cookies into categories so you can tailor your experience. You can "
+"update your preferences at any time using the cookie preferences button."
+
+#: templates/cookie-policy.php:21
+msgid "Retention of consent"
+msgstr "Retention of consent"
+
+#: templates/cookie-policy.php:22
+#, php-format
+msgid ""
+"Your consent choices are stored for %d days unless you change them earlier."
+msgstr ""
+"Your consent choices are stored for %d days unless you change them earlier."
+
+#: templates/cookie-policy.php:30 templates/privacy-policy.php:55
+#: src/Admin/Settings.php:215
+msgid "Service"
+msgstr "Service"
+
+#: templates/cookie-policy.php:31 templates/privacy-policy.php:57
+msgid "Purpose"
+msgstr "Purpose"
+
+#: templates/cookie-policy.php:32 src/Admin/Settings.php:219
+msgid "Cookies"
+msgstr "Cookies"
+
+#: templates/cookie-policy.php:33 templates/privacy-policy.php:37
+msgid "Retention"
+msgstr "Retention"
+
+#: templates/cookie-policy.php:50
+msgid "Managing cookies"
+msgstr "Managing cookies"
+
+#: templates/cookie-policy.php:51
+msgid ""
+"You can revisit your preferences using the cookie preferences button or "
+"adjust your browser settings to delete or block cookies. Blocking essential "
+"cookies may impact site functionality."
+msgstr ""
+"You can revisit your preferences using the cookie preferences button or "
+"adjust your browser settings to delete or block cookies. Blocking essential "
+"cookies may impact site functionality."
+
+#: templates/cookie-policy.php:53
+msgid "Last update"
+msgstr "Last update"
+
+#: templates/cookie-policy.php:54
+#, php-format
+msgid "This policy was generated on %s."
+msgstr "This policy was generated on %s."
+
+#: templates/privacy-policy.php:20
+msgid "Data controller"
+msgstr "Data controller"
+
+#: templates/privacy-policy.php:23
+#, php-format
+msgid "VAT/Tax ID: %s"
+msgstr "VAT/Tax ID: %s"
+
+#: templates/privacy-policy.php:25
+#, php-format
+msgid "Contact: %s"
+msgstr "Contact: %s"
+
+#: templates/privacy-policy.php:28
+msgid "Purposes of processing"
+msgstr "Purposes of processing"
+
+#: templates/privacy-policy.php:29
+msgid ""
+"We process personal data to provide our services, ensure security, measure "
+"performance and deliver personalized experiences in accordance with the "
+"selected consent preferences."
+msgstr ""
+"We process personal data to provide our services, ensure security, measure "
+"performance and deliver personalized experiences in accordance with the "
+"selected consent preferences."
+
+#: templates/privacy-policy.php:31
+msgid "Legal bases"
+msgstr "Legal bases"
+
+#: templates/privacy-policy.php:32
+msgid ""
+"Depending on the specific processing activity we rely on consent, "
+"contractual necessity or legitimate interest. Marketing and analytics tools "
+"are only activated after explicit consent."
+msgstr ""
+"Depending on the specific processing activity we rely on consent, "
+"contractual necessity or legitimate interest. Marketing and analytics tools "
+"are only activated after explicit consent."
+
+#: templates/privacy-policy.php:34
+msgid "Recipients and data transfers"
+msgstr "Recipients and data transfers"
+
+#: templates/privacy-policy.php:35
+msgid ""
+"Data may be shared with technology partners listed below. Transfers outside "
+"the EU/EEA are protected through adequacy decisions, Standard Contractual "
+"Clauses or equivalent safeguards."
+msgstr ""
+"Data may be shared with technology partners listed below. Transfers outside "
+"the EU/EEA are protected through adequacy decisions, Standard Contractual "
+"Clauses or equivalent safeguards."
+
+#: templates/privacy-policy.php:38
+msgid ""
+"Consent records are stored for the period required by law. Technical cookies "
+"follow the lifespan indicated in the cookie tables."
+msgstr ""
+"Consent records are stored for the period required by law. Technical cookies "
+"follow the lifespan indicated in the cookie tables."
+
+#: templates/privacy-policy.php:40
+msgid "Data subject rights"
+msgstr "Data subject rights"
+
+#: templates/privacy-policy.php:41
+msgid ""
+"You can request access, rectification, erasure, restriction, portability or "
+"object to processing by contacting us. You can withdraw consent at any time "
+"from the cookie preferences interface."
+msgstr ""
+"You can request access, rectification, erasure, restriction, portability or "
+"object to processing by contacting us. You can withdraw consent at any time "
+"from the cookie preferences interface."
+
+#: templates/privacy-policy.php:44
+msgid "Data Protection Officer"
+msgstr "Data Protection Officer"
+
+#: templates/privacy-policy.php:48
+msgid "Services and cookies"
+msgstr "Services and cookies"
+
+#: templates/privacy-policy.php:56 src/Admin/Settings.php:218
+msgid "Provider"
+msgstr "Provider"
+
+#: templates/privacy-policy.php:58
+msgid "Cookies & Retention"
+msgstr "Cookies & Retention"
+
+#: templates/privacy-policy.php:59
+msgid "Legal basis"
+msgstr "Legal basis"
+
+#: templates/privacy-policy.php:65 src/Admin/PolicyEditor.php:75
+msgid "Privacy policy"
+msgstr "Privacy policy"
+
+#: templates/privacy-policy.php:77
+msgid "How to exercise your rights"
+msgstr "How to exercise your rights"
+
+#: templates/privacy-policy.php:78
+msgid ""
+"Submit your request via email or the dedicated contact form. We will respond "
+"within one month and may request additional information to verify your "
+"identity."
+msgstr ""
+"Submit your request via email or the dedicated contact form. We will respond "
+"within one month and may request additional information to verify your "
+"identity."
+
+#: templates/privacy-policy.php:80
+msgid "Supervisory authority"
+msgstr "Supervisory authority"
+
+#: templates/privacy-policy.php:81
+msgid ""
+"If you believe your privacy rights have been violated you can lodge a "
+"complaint with the competent supervisory authority."
+msgstr ""
+"If you believe your privacy rights have been violated you can lodge a "
+"complaint with the competent supervisory authority."
+
+#: templates/preferences-button.php:13 src/Frontend/Shortcodes.php:164
+#: src/Frontend/Blocks.php:99 blocks/cookie-preferences/edit.js:65
+msgid "Manage cookie preferences"
+msgstr "Manage cookie preferences"
+
+#: src/Admin/ConsentLogTable.php:59 src/Admin/ConsentLogTable.php:180
+#: src/Admin/Settings.php:247 src/Admin/Settings.php:282
+#: src/Admin/Settings.php:317 src/Admin/Settings.php:340
+#: src/Admin/Settings.php:378 src/Admin/Settings.php:417
+#: src/Admin/PolicyEditor.php:59 src/Admin/PolicyEditor.php:106
+#: src/Admin/PolicyEditor.php:144
+msgid "Permission denied."
+msgstr "Permission denied."
+
+#: src/Admin/ConsentLogTable.php:99 src/Admin/Menu.php:65 src/Admin/Menu.php:66
+msgid "Consent log"
+msgstr "Consent log"
+
+#: src/Admin/ConsentLogTable.php:100
+msgid "Review consent events and export them for compliance."
+msgstr "Review consent events and export them for compliance."
+
+#: src/Admin/ConsentLogTable.php:104
+msgid "Search by ID, user agent or language"
+msgstr "Search by ID, user agent or language"
+
+#: src/Admin/ConsentLogTable.php:106
+msgid "All events"
+msgstr "All events"
+
+#: src/Admin/ConsentLogTable.php:111
+msgid "From"
+msgstr "From"
+
+#: src/Admin/ConsentLogTable.php:112
+msgid "To"
+msgstr "To"
+
+#: src/Admin/ConsentLogTable.php:113
+msgid "Filter"
+msgstr "Filter"
+
+#: src/Admin/ConsentLogTable.php:114
+msgid "Export CSV"
+msgstr "Export CSV"
+
+#: src/Admin/ConsentLogTable.php:118
+msgid "Last 30 days overview"
+msgstr "Last 30 days overview"
+
+#: src/Admin/ConsentLogTable.php:129
+msgid "Date"
+msgstr "Date"
+
+#: src/Admin/ConsentLogTable.php:130
+msgid "Event"
+msgstr "Event"
+
+#: src/Admin/ConsentLogTable.php:131
+msgid "Consent ID"
+msgstr "Consent ID"
+
+#: src/Admin/ConsentLogTable.php:132 blocks/privacy-policy/edit.js:65
+#: blocks/cookie-policy/edit.js:72 blocks/cookie-preferences/edit.js:93
+#: blocks/cookie-banner/edit.js:96
+msgid "Language"
+msgstr "Language"
+
+#: src/Admin/ConsentLogTable.php:133
+msgid "Revision"
+msgstr "Revision"
+
+#: src/Admin/ConsentLogTable.php:134
+msgid "User agent"
+msgstr "User agent"
+
+#: src/Admin/ConsentLogTable.php:135
+msgid "States"
+msgstr "States"
+
+#: src/Admin/ConsentLogTable.php:140
+msgid "No entries found."
+msgstr "No entries found."
+
+#: src/Admin/ConsentLogTable.php:150
+msgid "View"
+msgstr "View"
+
+#: src/Admin/ConsentLogTable.php:201
+msgid "Unable to open export stream."
+msgstr "Unable to open export stream."
+
+#: src/Admin/Menu.php:36 src/Admin/Menu.php:37
+msgid "Privacy & Cookie"
+msgstr "Privacy & Cookie"
+
+#: src/Admin/Menu.php:47 src/Admin/Menu.php:48
+msgid "Settings"
+msgstr "Settings"
+
+#: src/Admin/Menu.php:56 src/Admin/Menu.php:57 src/Admin/PolicyEditor.php:68
+msgid "Policy editor"
+msgstr "Policy editor"
+
+#: src/Admin/Menu.php:74 src/Admin/Menu.php:75 src/Admin/Settings.php:252
+msgid "Tools"
+msgstr "Tools"
+
+#: src/Admin/Menu.php:83 src/Admin/Menu.php:84 src/Admin/Settings.php:287
+msgid "Quick guide"
+msgstr "Quick guide"
+
+#: src/Admin/Settings.php:91
+msgid "You do not have permission to access this page."
+msgstr "You do not have permission to access this page."
+
+#: src/Admin/Settings.php:99
+msgid "Privacy & Cookie Settings"
+msgstr "Privacy & Cookie Settings"
+
+#: src/Admin/Settings.php:104
+msgid "Languages"
+msgstr "Languages"
+
+#: src/Admin/Settings.php:105
+msgid "Provide active languages (comma separated locale codes)."
+msgstr "Provide active languages (comma separated locale codes)."
+
+#: src/Admin/Settings.php:108
+msgid "Banner content"
+msgstr "Banner content"
+
+#: src/Admin/Settings.php:113 blocks/privacy-policy/edit.js:126
+#: blocks/cookie-policy/edit.js:135 blocks/cookie-preferences/edit.js:176
+#: blocks/cookie-banner/edit.js:207
+#, php-format
+msgid "Language: %s"
+msgstr "Language: %s"
+
+#: src/Admin/Settings.php:115
+msgid "Title"
+msgstr "Title"
+
+#: src/Admin/Settings.php:119
+msgid "Message"
+msgstr "Message"
+
+#: src/Admin/Settings.php:123
+msgid "Accept button label"
+msgstr "Accept button label"
+
+#: src/Admin/Settings.php:127
+msgid "Reject button label"
+msgstr "Reject button label"
+
+#: src/Admin/Settings.php:131
+msgid "Preferences button label"
+msgstr "Preferences button label"
+
+#: src/Admin/Settings.php:135
+msgid "Policy link URL"
+msgstr "Policy link URL"
+
+#: src/Admin/Settings.php:141 blocks/cookie-banner/edit.js:162
+msgid "Layout"
+msgstr "Layout"
+
+#: src/Admin/Settings.php:144
+msgid "Display type"
+msgstr "Display type"
+
+#: src/Admin/Settings.php:146
+msgid "Floating"
+msgstr "Floating"
+
+#: src/Admin/Settings.php:147
+msgid "Bar"
+msgstr "Bar"
+
+#: src/Admin/Settings.php:151 blocks/cookie-banner/edit.js:173
+msgid "Position"
+msgstr "Position"
+
+#: src/Admin/Settings.php:153 blocks/cookie-banner/edit.js:177
+msgid "Top"
+msgstr "Top"
+
+#: src/Admin/Settings.php:154 blocks/cookie-banner/edit.js:176
+msgid "Bottom"
+msgstr "Bottom"
+
+#: src/Admin/Settings.php:159
+msgid "Synchronize modal and button palette"
+msgstr "Synchronize modal and button palette"
+
+#: src/Admin/Settings.php:163
+msgid "Palette"
+msgstr "Palette"
+
+#: src/Admin/Settings.php:173
+msgid "Consent Mode defaults"
+msgstr "Consent Mode defaults"
+
+#: src/Admin/Settings.php:179
+msgid "Granted"
+msgstr "Granted"
+
+#: src/Admin/Settings.php:180
+msgid "Denied"
+msgstr "Denied"
+
+#: src/Admin/Settings.php:186
+msgid "Retention & Revision"
+msgstr "Retention & Revision"
+
+#: src/Admin/Settings.php:188
+msgid "Retention days"
+msgstr "Retention days"
+
+#: src/Admin/Settings.php:193
+msgid "Enable preview mode (admins only)"
+msgstr "Enable preview mode (admins only)"
+
+#: src/Admin/Settings.php:195
+#, php-format
+msgid "Current consent revision: %d"
+msgstr "Current consent revision: %d"
+
+#: src/Admin/Settings.php:196
+msgid "Force new consent (bump revision)"
+msgstr "Force new consent (bump revision)"
+
+#: src/Admin/Settings.php:198
+msgid "Controller & DPO"
+msgstr "Controller & DPO"
+
+#: src/Admin/Settings.php:200
+msgid "Organization name"
+msgstr "Organization name"
+
+#: src/Admin/Settings.php:201
+msgid "VAT / Tax ID"
+msgstr "VAT / Tax ID"
+
+#: src/Admin/Settings.php:202
+msgid "Registered address"
+msgstr "Registered address"
+
+#: src/Admin/Settings.php:203
+msgid "DPO name"
+msgstr "DPO name"
+
+#: src/Admin/Settings.php:204
+msgid "DPO email"
+msgstr "DPO email"
+
+#: src/Admin/Settings.php:205
+msgid "Privacy contact email"
+msgstr "Privacy contact email"
+
+#: src/Admin/Settings.php:208
+msgid "Save settings"
+msgstr "Save settings"
+
+#: src/Admin/Settings.php:211
+msgid "Detected services"
+msgstr "Detected services"
+
+#: src/Admin/Settings.php:216
+msgid "Category"
+msgstr "Category"
+
+#: src/Admin/Settings.php:217
+msgid "Detected"
+msgstr "Detected"
+
+#: src/Admin/Settings.php:227
+msgid "Yes"
+msgstr "Yes"
+
+#: src/Admin/Settings.php:227
+msgid "No"
+msgstr "No"
+
+#: src/Admin/Settings.php:235
+msgid ""
+"Use the policy editor to regenerate your documents after services change."
+msgstr ""
+"Use the policy editor to regenerate your documents after services change."
+
+#: src/Admin/Settings.php:253
+msgid "Export or import configuration, regenerate policies and reset revision."
+msgstr ""
+"Export or import configuration, regenerate policies and reset revision."
+
+#: src/Admin/Settings.php:257
+msgid "Download settings JSON"
+msgstr "Download settings JSON"
+
+#: src/Admin/Settings.php:263
+msgid "Import settings"
+msgstr "Import settings"
+
+#: src/Admin/Settings.php:268
+msgid "Regenerate policies"
+msgstr "Regenerate policies"
+
+#: src/Admin/Settings.php:270
+msgid "Reset consent (bump revision)"
+msgstr "Reset consent (bump revision)"
+
+#: src/Admin/Settings.php:288
+msgid "Shortcodes"
+msgstr "Shortcodes"
+
+#: src/Admin/Settings.php:295
+msgid "Blocks"
+msgstr "Blocks"
+
+#: src/Admin/Settings.php:296
+msgid ""
+"Use the Privacy Policy, Cookie Policy, Cookie Preferences and Cookie Banner "
+"blocks inside the block editor. Each block mirrors the shortcode output."
+msgstr ""
+"Use the Privacy Policy, Cookie Policy, Cookie Preferences and Cookie Banner "
+"blocks inside the block editor. Each block mirrors the shortcode output."
+
+#: src/Admin/Settings.php:297
+msgid "Hooks"
+msgstr "Hooks"
+
+#: src/Admin/Settings.php:304
+msgid "Legal notice"
+msgstr "Legal notice"
+
+#: src/Admin/Settings.php:305
+msgid ""
+"This plugin provides technical tooling to help comply with privacy "
+"regulations. Consult your legal advisor to validate the generated documents."
+msgstr ""
+"This plugin provides technical tooling to help comply with privacy "
+"regulations. Consult your legal advisor to validate the generated documents."
+
+#: src/Admin/PolicyEditor.php:69
+msgid ""
+"Customize the generated documents or regenerate them using the detector."
+msgstr ""
+"Customize the generated documents or regenerate them using the detector."
+
+#: src/Admin/PolicyEditor.php:78
+msgid "Cookie policy"
+msgstr "Cookie policy"
+
+#: src/Admin/PolicyEditor.php:81
+msgid "Save policies"
+msgstr "Save policies"
+
+#: src/Admin/PolicyEditor.php:87
+msgid "Detect integrations and regenerate"
+msgstr "Detect integrations and regenerate"
+
+#: src/Admin/PolicyEditor.php:92
+msgid "Differences between generated templates and current documents"
+msgstr "Differences between generated templates and current documents"
+
+#: src/Admin/PolicyEditor.php:199
+msgid "Privacy policy diff"
+msgstr "Privacy policy diff"
+
+#: src/Admin/PolicyEditor.php:203
+msgid "Cookie policy diff"
+msgstr "Cookie policy diff"
+
+#: src/Admin/DashboardWidget.php:47
+msgid "Privacy & Cookie overview"
+msgstr "Privacy & Cookie overview"
+
+#: src/Admin/DashboardWidget.php:59
+msgid "Total events in the last 30 days:"
+msgstr "Total events in the last 30 days:"
+
+#: src/Admin/DashboardWidget.php:65
+msgid "View consent log"
+msgstr "View consent log"
+
+#: src/Frontend/Shortcodes.php:178
+#, php-format
+msgid "Last consent: %s"
+msgstr "Last consent: %s"
+
+#: src/Utils/Options.php:129
+msgid "Strictly necessary"
+msgstr "Strictly necessary"
+
+#: src/Utils/Options.php:130
+msgid ""
+"Essential cookies required for the website to function and cannot be "
+"disabled."
+msgstr ""
+"Essential cookies required for the website to function and cannot be "
+"disabled."
+
+#: src/Utils/Options.php:135 blocks/cookie-banner/edit.js:147
+msgid "Preferences"
+msgstr "Preferences"
+
+#: src/Utils/Options.php:136
+msgid "Store user preferences such as language or location."
+msgstr "Store user preferences such as language or location."
+
+#: src/Utils/Options.php:141
+msgid "Statistics"
+msgstr "Statistics"
+
+#: src/Utils/Options.php:142
+msgid "Collect anonymous statistics to improve our services."
+msgstr "Collect anonymous statistics to improve our services."
+
+#: src/Utils/Options.php:147
+msgid "Marketing"
+msgstr "Marketing"
+
+#: src/Utils/Options.php:148
+msgid "Enable personalized advertising and tracking."
+msgstr "Enable personalized advertising and tracking."
+
+#: src/Utils/Options.php:158
+msgid "We value your privacy"
+msgstr "We value your privacy"
+
+#: src/Utils/Options.php:159
+msgid ""
+"We use cookies to improve your experience. You can accept all cookies or "
+"manage your preferences."
+msgstr ""
+"We use cookies to improve your experience. You can accept all cookies or "
+"manage your preferences."
+
+#: src/Utils/Options.php:160
+msgid "Accept all"
+msgstr "Accept all"
+
+#: src/Utils/Options.php:161
+msgid "Reject all"
+msgstr "Reject all"
+
+#: src/Utils/Options.php:162
+msgid "Manage preferences"
+msgstr "Manage preferences"
+
+#: src/Utils/Options.php:441
+msgid "Privacy Policy"
+msgstr "Privacy Policy"
+
+#: src/Utils/Options.php:441
+msgid "Cookie Policy"
+msgstr "Cookie Policy"
+
+#: src/Consent/ExporterEraser.php:60 src/Consent/ExporterEraser.php:76
+msgid "FP Privacy consent log"
+msgstr "FP Privacy consent log"
+
+#: src/Consent/ExporterEraser.php:113
+msgid "Consent Log Entry"
+msgstr "Consent Log Entry"
+
+#: src/REST/Controller.php:141
+msgid "Invalid security token."
+msgstr "Invalid security token."
+
+#: src/REST/Controller.php:148
+msgid "Too many requests. Please try again later."
+msgstr "Too many requests. Please try again later."
+
+#: blocks/privacy-policy/edit.js:61
+msgid "FP Privacy Policy"
+msgstr "FP Privacy Policy"
+
+#: blocks/cookie-policy/edit.js:61
+msgid "FP Cookie Policy"
+msgstr "FP Cookie Policy"
+
+#: blocks/cookie-preferences/edit.js:65
+msgid "FP Cookie Preferences"
+msgstr "FP Cookie Preferences"
+
+#: blocks/cookie-banner/edit.js:63
+msgid "FP Cookie Banner"
+msgstr "FP Cookie Banner"
+
+#: blocks/cookie-preferences/edit.js:11
+msgid ""
+"Opens the cookie preferences modal so visitors can review or update their "
+"consent."
+msgstr ""
+"Opens the cookie preferences modal so visitors can review or update their "
+"consent."
+
+#: blocks/privacy-policy/edit.js:31 blocks/cookie-policy/edit.js:31 #:
+#: blocks/cookie-preferences/edit.js:35 blocks/cookie-banner/edit.js:33
+msgid "Inherit current locale"
+msgstr "Inherit current locale"
+
+#: blocks/privacy-policy/edit.js:83 blocks/cookie-policy/edit.js:79 #:
+#: blocks/cookie-preferences/edit.js:100 blocks/cookie-banner/edit.js:103
+msgid "Pick one of the configured languages or type a custom code."
+msgstr "Pick one of the configured languages or type a custom code."
+
+#: blocks/privacy-policy/edit.js:87 blocks/cookie-policy/edit.js:83 #:
+#: blocks/cookie-preferences/edit.js:104 blocks/cookie-banner/edit.js:107
+msgid "Language code"
+msgstr "Language code"
+
+#: blocks/privacy-policy/edit.js:94 blocks/cookie-policy/edit.js:91 #:
+#: blocks/cookie-preferences/edit.js:112
+msgid "Leave empty to use the current site locale."
+msgstr "Leave empty to use the current site locale."
+
+#: blocks/cookie-banner/edit.js:112
+msgid "Leave empty to match the current page locale."
+msgstr "Leave empty to match the current page locale."
+
+#: blocks/privacy-policy/edit.js:104 blocks/cookie-policy/edit.js:101 #:
+#: blocks/cookie-preferences/edit.js:122 blocks/cookie-banner/edit.js:124
+msgid "Available languages:"
+msgstr "Available languages:"
+
+#: blocks/privacy-policy/edit.js:123
+msgid "Privacy policy settings"
+msgstr "Privacy policy settings"
+
+#: blocks/privacy-policy/edit.js:135
+msgid "Privacy policy preview"
+msgstr "Privacy policy preview"
+
+#: blocks/privacy-policy/edit.js:141
+msgid ""
+"This block prints the generated privacy policy on the front-end. Configure "
+"the language to review locale-specific content while editing."
+msgstr ""
+"This block prints the generated privacy policy on the front-end. Configure "
+"the language to review locale-specific content while editing."
+
+#: blocks/cookie-policy/edit.js:127
+msgid "Cookie policy settings"
+msgstr "Cookie policy settings"
+
+#: blocks/cookie-policy/edit.js:139
+msgid "Cookie policy preview"
+msgstr "Cookie policy preview"
+
+#: blocks/privacy-policy/edit.js:145 blocks/cookie-policy/edit.js:151
+msgid "Using the current site locale"
+msgstr "Using the current site locale"
+
+#: blocks/privacy-policy/edit.js:149 blocks/cookie-policy/edit.js:159
+msgid ""
+"No additional languages are configured yet. Add them from the plugin "
+"settings to manage locale-specific policies."
+msgstr ""
+"No additional languages are configured yet. Add them from the plugin "
+"settings to manage locale-specific policies."
+
+#: blocks/privacy-policy/edit.js:162
+msgid "Owner details, contact references, and data subject rights."
+msgstr "Owner details, contact references, and data subject rights."
+
+#: blocks/privacy-policy/edit.js:167
+msgid "Legal bases and processing purposes grouped by service categories."
+msgstr "Legal bases and processing purposes grouped by service categories."
+
+#: blocks/privacy-policy/edit.js:172
+msgid "Automatic updates include detected services and consent revision notes."
+msgstr ""
+"Automatic updates include detected services and consent revision notes."
+
+#: blocks/cookie-policy/edit.js:144
+msgid ""
+"This block prints the generated cookie policy on the front-end. Configure "
+"the language to review locale-specific content while editing."
+msgstr ""
+"This block prints the generated cookie policy on the front-end. Configure "
+"the language to review locale-specific content while editing."
+
+#: blocks/cookie-policy/edit.js:170
+msgid "Service overview, legal bases, and retention for each category."
+msgstr "Service overview, legal bases, and retention for each category."
+
+#: blocks/cookie-policy/edit.js:175
+msgid "Cookie tables are rendered automatically from detected services."
+msgstr "Cookie tables are rendered automatically from detected services."
+
+#: blocks/cookie-policy/edit.js:180
+msgid "Visitors see language-specific contacts and owner details."
+msgstr "Visitors see language-specific contacts and owner details."
+
+#: blocks/cookie-preferences/edit.js:144
+msgid "Cookie preferences settings"
+msgstr "Cookie preferences settings"
+
+#: blocks/cookie-preferences/edit.js:148
+msgid "Button label"
+msgstr "Button label"
+
+#: blocks/cookie-preferences/edit.js:156
+msgid "Accessibility description"
+msgstr "Accessibility description"
+
+#: blocks/cookie-preferences/edit.js:159
+msgid "Announced by assistive technologies when the button receives focus."
+msgstr "Announced by assistive technologies when the button receives focus."
+
+#: blocks/cookie-banner/edit.js:158
+msgid "Cookie banner settings"
+msgstr "Cookie banner settings"
+
+#: blocks/cookie-banner/edit.js:207 blocks/cookie-banner/edit.js:231
+msgid "Floating panel"
+msgstr "Floating panel"
+
+#: blocks/cookie-banner/edit.js:206 blocks/cookie-banner/edit.js:232
+msgid "Full-width bar"
+msgstr "Full-width bar"
+
+#: blocks/cookie-banner/edit.js:251
+msgid "Always display this banner instance"
+msgstr "Always display this banner instance"
+
+#: blocks/cookie-banner/edit.js:256
+msgid ""
+"Force the banner to render even if the visitor has already provided consent."
+msgstr ""
+"Force the banner to render even if the visitor has already provided consent."
+
+#: blocks/cookie-banner/edit.js:263
+msgid "Cookie banner preview"
+msgstr "Cookie banner preview"
+
+#: blocks/cookie-banner/edit.js:140
+msgid "Sample banner title"
+msgstr "Sample banner title"
+
+#: blocks/cookie-banner/edit.js:144
+msgid "Update the banner texts from the plugin settings to preview them here."
+msgstr "Update the banner texts from the plugin settings to preview them here."
+
+#: blocks/cookie-banner/edit.js:283
+msgid ""
+"Save the plugin settings after editing banner content to preview the actual "
+"copy for each language."
+msgstr ""
+"Save the plugin settings after editing banner content to preview the actual "
+"copy for each language."
+
+#: blocks/cookie-banner/edit.js:298
+msgid "Forced display enabled"
+msgstr "Forced display enabled"
+
+#: blocks/cookie-banner/edit.js:308
+msgid ""
+"No additional languages are configured yet. Add them from the plugin "
+"settings to customise the banner per locale."
+msgstr ""
+"No additional languages are configured yet. Add them from the plugin "
+"settings to customise the banner per locale."
+
+#: blocks/cookie-banner/edit.js:317
+msgid ""
+"Forced display bypasses the automatic hide behaviour. Confirm the banner "
+"placement remains accessible across devices."
+msgstr ""
+"Forced display bypasses the automatic hide behaviour. Confirm the banner "
+"placement remains accessible across devices."
+
+#: blocks/cookie-banner/edit.js:145
+msgid "Accept"
+msgstr "Accept"
+
+#: blocks/cookie-banner/edit.js:146
+msgid "Reject"
+msgstr "Reject"
+
+#: blocks/cookie-banner/edit.js:268
+msgid ""
+"Use the inspector controls to review layout, position, and language "
+"overrides before publishing the banner."
+msgstr ""
+"Use the inspector controls to review layout, position, and language "
+"overrides before publishing the banner."
+
+#: blocks/cookie-banner/edit.js:336
+msgid ""
+"Floating panels anchor near a corner whereas bars stretch across the "
+"viewport edge."
+msgstr ""
+"Floating panels anchor near a corner whereas bars stretch across the "
+"viewport edge."
+
+#: blocks/cookie-banner/edit.js:344
+msgid ""
+"Language overrides let you review translated banner texts without switching "
+"the editor UI."
+msgstr ""
+"Language overrides let you review translated banner texts without switching "
+"the editor UI."
+
+#: blocks/cookie-banner/edit.js:352
+msgid ""
+"Forced display keeps the banner visible when manually embedding it alongside "
+"other content."
+msgstr ""
+"Forced display keeps the banner visible when manually embedding it alongside "
+"other content."
+
+#: blocks/cookie-preferences/edit.js:181
+msgid "Cookie preferences preview"
+msgstr "Cookie preferences preview"
+
+#: blocks/cookie-preferences/edit.js:187
+msgid ""
+"The block renders a button that opens the cookie preferences modal so "
+"visitors can change their choices."
+msgstr ""
+"The block renders a button that opens the cookie preferences modal so "
+"visitors can change their choices."
+
+#: blocks/cookie-preferences/edit.js:197
+msgid ""
+"No additional languages are configured yet. Add them from the plugin "
+"settings to customize button text per locale."
+msgstr ""
+"No additional languages are configured yet. Add them from the plugin "
+"settings to customize button text per locale."
+
+#: blocks/cookie-preferences/edit.js:219
+msgid ""
+"On the front-end the button receives focus styles that meet AA contrast "
+"requirements."
+msgstr ""
+"On the front-end the button receives focus styles that meet AA contrast "
+"requirements."
+
+#: blocks/cookie-preferences/edit.js:227
+msgid ""
+"Screen readers announce the accessibility description before opening the "
+"modal."
+msgstr ""
+"Screen readers announce the accessibility description before opening the "
+"modal."
+
+#: blocks/cookie-preferences/edit.js:235
+msgid ""
+"The modal displays a summary of the last recorded consent for additional "
+"context."
+msgstr ""
+"The modal displays a summary of the last recorded consent for additional "
+"context."

--- a/fp-privacy-cookie-policy/languages/fp-privacy.pot
+++ b/fp-privacy-cookie-policy/languages/fp-privacy.pot
@@ -1,0 +1,880 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: FP Privacy and Cookie Policy 0.1.0\n"
+"Report-Msgid-Bugs-To: https://francescopasseri.com\n"
+"POT-Creation-Date: 2025-02-14 00:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: xgettext\n"
+"X-Domain: fp-privacy\n"
+
+#: templates/cookie-policy.php:15
+msgid "About cookies"
+msgstr ""
+
+#: templates/cookie-policy.php:16
+msgid ""
+"Cookies are small text files stored on your device. They allow us to "
+"remember your preferences, ensure the website works properly and measure "
+"performance. Some cookies are strictly necessary while others require your "
+"consent."
+msgstr ""
+
+#: templates/cookie-policy.php:18
+msgid "How we use cookies"
+msgstr ""
+
+#: templates/cookie-policy.php:19
+msgid ""
+"We group cookies into categories so you can tailor your experience. You can "
+"update your preferences at any time using the cookie preferences button."
+msgstr ""
+
+#: templates/cookie-policy.php:21
+msgid "Retention of consent"
+msgstr ""
+
+#: templates/cookie-policy.php:22
+#, php-format
+msgid ""
+"Your consent choices are stored for %d days unless you change them earlier."
+msgstr ""
+
+#: templates/cookie-policy.php:30 templates/privacy-policy.php:55
+#: src/Admin/Settings.php:215
+msgid "Service"
+msgstr ""
+
+#: templates/cookie-policy.php:31 templates/privacy-policy.php:57
+msgid "Purpose"
+msgstr ""
+
+#: templates/cookie-policy.php:32 src/Admin/Settings.php:219
+msgid "Cookies"
+msgstr ""
+
+#: templates/cookie-policy.php:33 templates/privacy-policy.php:37
+msgid "Retention"
+msgstr ""
+
+#: templates/cookie-policy.php:50
+msgid "Managing cookies"
+msgstr ""
+
+#: templates/cookie-policy.php:51
+msgid ""
+"You can revisit your preferences using the cookie preferences button or "
+"adjust your browser settings to delete or block cookies. Blocking essential "
+"cookies may impact site functionality."
+msgstr ""
+
+#: templates/cookie-policy.php:53
+msgid "Last update"
+msgstr ""
+
+#: templates/cookie-policy.php:54
+#, php-format
+msgid "This policy was generated on %s."
+msgstr ""
+
+#: templates/privacy-policy.php:20
+msgid "Data controller"
+msgstr ""
+
+#: templates/privacy-policy.php:23
+#, php-format
+msgid "VAT/Tax ID: %s"
+msgstr ""
+
+#: templates/privacy-policy.php:25
+#, php-format
+msgid "Contact: %s"
+msgstr ""
+
+#: templates/privacy-policy.php:28
+msgid "Purposes of processing"
+msgstr ""
+
+#: templates/privacy-policy.php:29
+msgid ""
+"We process personal data to provide our services, ensure security, measure "
+"performance and deliver personalized experiences in accordance with the "
+"selected consent preferences."
+msgstr ""
+
+#: templates/privacy-policy.php:31
+msgid "Legal bases"
+msgstr ""
+
+#: templates/privacy-policy.php:32
+msgid ""
+"Depending on the specific processing activity we rely on consent, "
+"contractual necessity or legitimate interest. Marketing and analytics tools "
+"are only activated after explicit consent."
+msgstr ""
+
+#: templates/privacy-policy.php:34
+msgid "Recipients and data transfers"
+msgstr ""
+
+#: templates/privacy-policy.php:35
+msgid ""
+"Data may be shared with technology partners listed below. Transfers outside "
+"the EU/EEA are protected through adequacy decisions, Standard Contractual "
+"Clauses or equivalent safeguards."
+msgstr ""
+
+#: templates/privacy-policy.php:38
+msgid ""
+"Consent records are stored for the period required by law. Technical cookies "
+"follow the lifespan indicated in the cookie tables."
+msgstr ""
+
+#: templates/privacy-policy.php:40
+msgid "Data subject rights"
+msgstr ""
+
+#: templates/privacy-policy.php:41
+msgid ""
+"You can request access, rectification, erasure, restriction, portability or "
+"object to processing by contacting us. You can withdraw consent at any time "
+"from the cookie preferences interface."
+msgstr ""
+
+#: templates/privacy-policy.php:44
+msgid "Data Protection Officer"
+msgstr ""
+
+#: templates/privacy-policy.php:48
+msgid "Services and cookies"
+msgstr ""
+
+#: templates/privacy-policy.php:56 src/Admin/Settings.php:218
+msgid "Provider"
+msgstr ""
+
+#: templates/privacy-policy.php:58
+msgid "Cookies & Retention"
+msgstr ""
+
+#: templates/privacy-policy.php:59
+msgid "Legal basis"
+msgstr ""
+
+#: templates/privacy-policy.php:65 src/Admin/PolicyEditor.php:75
+msgid "Privacy policy"
+msgstr ""
+
+#: templates/privacy-policy.php:77
+msgid "How to exercise your rights"
+msgstr ""
+
+#: templates/privacy-policy.php:78
+msgid ""
+"Submit your request via email or the dedicated contact form. We will respond "
+"within one month and may request additional information to verify your "
+"identity."
+msgstr ""
+
+#: templates/privacy-policy.php:80
+msgid "Supervisory authority"
+msgstr ""
+
+#: templates/privacy-policy.php:81
+msgid ""
+"If you believe your privacy rights have been violated you can lodge a "
+"complaint with the competent supervisory authority."
+msgstr ""
+
+#: templates/preferences-button.php:13 src/Frontend/Shortcodes.php:164
+#: src/Frontend/Blocks.php:99 blocks/cookie-preferences/edit.js:65
+msgid "Manage cookie preferences"
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:59 src/Admin/ConsentLogTable.php:180
+#: src/Admin/Settings.php:247 src/Admin/Settings.php:282
+#: src/Admin/Settings.php:317 src/Admin/Settings.php:340
+#: src/Admin/Settings.php:378 src/Admin/Settings.php:417
+#: src/Admin/PolicyEditor.php:59 src/Admin/PolicyEditor.php:106
+#: src/Admin/PolicyEditor.php:144
+msgid "Permission denied."
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:99 src/Admin/Menu.php:65 src/Admin/Menu.php:66
+msgid "Consent log"
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:100
+msgid "Review consent events and export them for compliance."
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:104
+msgid "Search by ID, user agent or language"
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:106
+msgid "All events"
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:111
+msgid "From"
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:112
+msgid "To"
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:113
+msgid "Filter"
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:114
+msgid "Export CSV"
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:118
+msgid "Last 30 days overview"
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:129
+msgid "Date"
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:130
+msgid "Event"
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:131
+msgid "Consent ID"
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:132
+#: blocks/privacy-policy/edit.js:65
+#: blocks/cookie-policy/edit.js:72
+#: blocks/cookie-preferences/edit.js:93
+#: blocks/cookie-banner/edit.js:96
+msgid "Language"
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:133
+msgid "Revision"
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:134
+msgid "User agent"
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:135
+msgid "States"
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:140
+msgid "No entries found."
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:150
+msgid "View"
+msgstr ""
+
+#: src/Admin/ConsentLogTable.php:201
+msgid "Unable to open export stream."
+msgstr ""
+
+#: src/Admin/Menu.php:36 src/Admin/Menu.php:37
+msgid "Privacy & Cookie"
+msgstr ""
+
+#: src/Admin/Menu.php:47 src/Admin/Menu.php:48
+msgid "Settings"
+msgstr ""
+
+#: src/Admin/Menu.php:56 src/Admin/Menu.php:57 src/Admin/PolicyEditor.php:68
+msgid "Policy editor"
+msgstr ""
+
+#: src/Admin/Menu.php:74 src/Admin/Menu.php:75 src/Admin/Settings.php:252
+msgid "Tools"
+msgstr ""
+
+#: src/Admin/Menu.php:83 src/Admin/Menu.php:84 src/Admin/Settings.php:287
+msgid "Quick guide"
+msgstr ""
+
+#: src/Admin/Settings.php:91
+msgid "You do not have permission to access this page."
+msgstr ""
+
+#: src/Admin/Settings.php:99
+msgid "Privacy & Cookie Settings"
+msgstr ""
+
+#: src/Admin/Settings.php:104
+msgid "Languages"
+msgstr ""
+
+#: src/Admin/Settings.php:105
+msgid "Provide active languages (comma separated locale codes)."
+msgstr ""
+
+#: src/Admin/Settings.php:108
+msgid "Banner content"
+msgstr ""
+
+#: src/Admin/Settings.php:113
+#: blocks/privacy-policy/edit.js:126
+#: blocks/cookie-policy/edit.js:135
+#: blocks/cookie-preferences/edit.js:176
+#: blocks/cookie-banner/edit.js:207
+#, php-format
+msgid "Language: %s"
+msgstr ""
+
+#: src/Admin/Settings.php:115
+msgid "Title"
+msgstr ""
+
+#: src/Admin/Settings.php:119
+msgid "Message"
+msgstr ""
+
+#: src/Admin/Settings.php:123
+msgid "Accept button label"
+msgstr ""
+
+#: src/Admin/Settings.php:127
+msgid "Reject button label"
+msgstr ""
+
+#: src/Admin/Settings.php:131
+msgid "Preferences button label"
+msgstr ""
+
+#: src/Admin/Settings.php:135
+msgid "Policy link URL"
+msgstr ""
+
+#: src/Admin/Settings.php:141
+#: blocks/cookie-banner/edit.js:162
+msgid "Layout"
+msgstr ""
+
+#: src/Admin/Settings.php:144
+msgid "Display type"
+msgstr ""
+
+#: src/Admin/Settings.php:146
+msgid "Floating"
+msgstr ""
+
+#: src/Admin/Settings.php:147
+msgid "Bar"
+msgstr ""
+
+#: src/Admin/Settings.php:151
+#: blocks/cookie-banner/edit.js:173
+msgid "Position"
+msgstr ""
+
+#: src/Admin/Settings.php:153
+#: blocks/cookie-banner/edit.js:177
+msgid "Top"
+msgstr ""
+
+#: src/Admin/Settings.php:154
+#: blocks/cookie-banner/edit.js:176
+msgid "Bottom"
+msgstr ""
+
+#: src/Admin/Settings.php:159
+msgid "Synchronize modal and button palette"
+msgstr ""
+
+#: src/Admin/Settings.php:163
+msgid "Palette"
+msgstr ""
+
+#: src/Admin/Settings.php:173
+msgid "Consent Mode defaults"
+msgstr ""
+
+#: src/Admin/Settings.php:179
+msgid "Granted"
+msgstr ""
+
+#: src/Admin/Settings.php:180
+msgid "Denied"
+msgstr ""
+
+#: src/Admin/Settings.php:186
+msgid "Retention & Revision"
+msgstr ""
+
+#: src/Admin/Settings.php:188
+msgid "Retention days"
+msgstr ""
+
+#: src/Admin/Settings.php:193
+msgid "Enable preview mode (admins only)"
+msgstr ""
+
+#: src/Admin/Settings.php:195
+#, php-format
+msgid "Current consent revision: %d"
+msgstr ""
+
+#: src/Admin/Settings.php:196
+msgid "Force new consent (bump revision)"
+msgstr ""
+
+#: src/Admin/Settings.php:198
+msgid "Controller & DPO"
+msgstr ""
+
+#: src/Admin/Settings.php:200
+msgid "Organization name"
+msgstr ""
+
+#: src/Admin/Settings.php:201
+msgid "VAT / Tax ID"
+msgstr ""
+
+#: src/Admin/Settings.php:202
+msgid "Registered address"
+msgstr ""
+
+#: src/Admin/Settings.php:203
+msgid "DPO name"
+msgstr ""
+
+#: src/Admin/Settings.php:204
+msgid "DPO email"
+msgstr ""
+
+#: src/Admin/Settings.php:205
+msgid "Privacy contact email"
+msgstr ""
+
+#: src/Admin/Settings.php:208
+msgid "Save settings"
+msgstr ""
+
+#: src/Admin/Settings.php:211
+msgid "Detected services"
+msgstr ""
+
+#: src/Admin/Settings.php:216
+msgid "Category"
+msgstr ""
+
+#: src/Admin/Settings.php:217
+msgid "Detected"
+msgstr ""
+
+#: src/Admin/Settings.php:227
+msgid "Yes"
+msgstr ""
+
+#: src/Admin/Settings.php:227
+msgid "No"
+msgstr ""
+
+#: src/Admin/Settings.php:235
+msgid ""
+"Use the policy editor to regenerate your documents after services change."
+msgstr ""
+
+#: src/Admin/Settings.php:253
+msgid "Export or import configuration, regenerate policies and reset revision."
+msgstr ""
+
+#: src/Admin/Settings.php:257
+msgid "Download settings JSON"
+msgstr ""
+
+#: src/Admin/Settings.php:263
+msgid "Import settings"
+msgstr ""
+
+#: src/Admin/Settings.php:268
+msgid "Regenerate policies"
+msgstr ""
+
+#: src/Admin/Settings.php:270
+msgid "Reset consent (bump revision)"
+msgstr ""
+
+#: src/Admin/Settings.php:288
+msgid "Shortcodes"
+msgstr ""
+
+#: src/Admin/Settings.php:295
+msgid "Blocks"
+msgstr ""
+
+#: src/Admin/Settings.php:296
+msgid ""
+"Use the Privacy Policy, Cookie Policy, Cookie Preferences and Cookie Banner "
+"blocks inside the block editor. Each block mirrors the shortcode output."
+msgstr ""
+
+#: src/Admin/Settings.php:297
+msgid "Hooks"
+msgstr ""
+
+#: src/Admin/Settings.php:304
+msgid "Legal notice"
+msgstr ""
+
+#: src/Admin/Settings.php:305
+msgid ""
+"This plugin provides technical tooling to help comply with privacy "
+"regulations. Consult your legal advisor to validate the generated documents."
+msgstr ""
+
+#: src/Admin/PolicyEditor.php:69
+msgid ""
+"Customize the generated documents or regenerate them using the detector."
+msgstr ""
+
+#: src/Admin/PolicyEditor.php:78
+msgid "Cookie policy"
+msgstr ""
+
+#: src/Admin/PolicyEditor.php:81
+msgid "Save policies"
+msgstr ""
+
+#: src/Admin/PolicyEditor.php:87
+msgid "Detect integrations and regenerate"
+msgstr ""
+
+#: src/Admin/PolicyEditor.php:92
+msgid "Differences between generated templates and current documents"
+msgstr ""
+
+#: src/Admin/PolicyEditor.php:199
+msgid "Privacy policy diff"
+msgstr ""
+
+#: src/Admin/PolicyEditor.php:203
+msgid "Cookie policy diff"
+msgstr ""
+
+#: src/Admin/DashboardWidget.php:47
+msgid "Privacy & Cookie overview"
+msgstr ""
+
+#: src/Admin/DashboardWidget.php:59
+msgid "Total events in the last 30 days:"
+msgstr ""
+
+#: src/Admin/DashboardWidget.php:65
+msgid "View consent log"
+msgstr ""
+
+#: src/Frontend/Shortcodes.php:178
+#, php-format
+msgid "Last consent: %s"
+msgstr ""
+
+#: src/Utils/Options.php:129
+msgid "Strictly necessary"
+msgstr ""
+
+#: src/Utils/Options.php:130
+msgid ""
+"Essential cookies required for the website to function and cannot be "
+"disabled."
+msgstr ""
+
+#: src/Utils/Options.php:135 blocks/cookie-banner/edit.js:147
+msgid "Preferences"
+msgstr ""
+
+#: src/Utils/Options.php:136
+msgid "Store user preferences such as language or location."
+msgstr ""
+
+#: src/Utils/Options.php:141
+msgid "Statistics"
+msgstr ""
+
+#: src/Utils/Options.php:142
+msgid "Collect anonymous statistics to improve our services."
+msgstr ""
+
+#: src/Utils/Options.php:147
+msgid "Marketing"
+msgstr ""
+
+#: src/Utils/Options.php:148
+msgid "Enable personalized advertising and tracking."
+msgstr ""
+
+#: src/Utils/Options.php:158
+msgid "We value your privacy"
+msgstr ""
+
+#: src/Utils/Options.php:159
+msgid ""
+"We use cookies to improve your experience. You can accept all cookies or "
+"manage your preferences."
+msgstr ""
+
+#: src/Utils/Options.php:160
+msgid "Accept all"
+msgstr ""
+
+#: src/Utils/Options.php:161
+msgid "Reject all"
+msgstr ""
+
+#: src/Utils/Options.php:162
+msgid "Manage preferences"
+msgstr ""
+
+#: src/Utils/Options.php:441
+msgid "Privacy Policy"
+msgstr ""
+
+#: src/Utils/Options.php:441
+msgid "Cookie Policy"
+msgstr ""
+
+#: src/Consent/ExporterEraser.php:60 src/Consent/ExporterEraser.php:76
+msgid "FP Privacy consent log"
+msgstr ""
+
+#: src/Consent/ExporterEraser.php:113
+msgid "Consent Log Entry"
+msgstr ""
+
+#: src/REST/Controller.php:141
+msgid "Invalid security token."
+msgstr ""
+
+#: src/REST/Controller.php:148
+msgid "Too many requests. Please try again later."
+msgstr ""
+
+#: blocks/privacy-policy/edit.js:61
+msgid "FP Privacy Policy"
+msgstr ""
+
+#: blocks/cookie-policy/edit.js:61
+msgid "FP Cookie Policy"
+msgstr ""
+
+#: blocks/cookie-preferences/edit.js:65
+msgid "FP Cookie Preferences"
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:63
+msgid "FP Cookie Banner"
+msgstr ""
+
+#: blocks/cookie-preferences/edit.js:11
+msgid "Opens the cookie preferences modal so visitors can review or update their consent."
+msgstr ""
+
+#: blocks/privacy-policy/edit.js:31 blocks/cookie-policy/edit.js:31 \
+#: blocks/cookie-preferences/edit.js:35 blocks/cookie-banner/edit.js:33
+msgid "Inherit current locale"
+msgstr ""
+
+#: blocks/privacy-policy/edit.js:83 blocks/cookie-policy/edit.js:79 \
+#: blocks/cookie-preferences/edit.js:100 blocks/cookie-banner/edit.js:103
+msgid "Pick one of the configured languages or type a custom code."
+msgstr ""
+
+#: blocks/privacy-policy/edit.js:87 blocks/cookie-policy/edit.js:83 \
+#: blocks/cookie-preferences/edit.js:104 blocks/cookie-banner/edit.js:107
+msgid "Language code"
+msgstr ""
+
+#: blocks/privacy-policy/edit.js:94 blocks/cookie-policy/edit.js:91 \
+#: blocks/cookie-preferences/edit.js:112
+msgid "Leave empty to use the current site locale."
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:112
+msgid "Leave empty to match the current page locale."
+msgstr ""
+
+#: blocks/privacy-policy/edit.js:104 blocks/cookie-policy/edit.js:101 \
+#: blocks/cookie-preferences/edit.js:122 blocks/cookie-banner/edit.js:124
+msgid "Available languages:"
+msgstr ""
+
+#: blocks/privacy-policy/edit.js:123
+msgid "Privacy policy settings"
+msgstr ""
+
+#: blocks/privacy-policy/edit.js:135
+msgid "Privacy policy preview"
+msgstr ""
+
+#: blocks/privacy-policy/edit.js:141
+msgid "This block prints the generated privacy policy on the front-end. Configure the language to review locale-specific content while editing."
+msgstr ""
+
+#: blocks/cookie-policy/edit.js:127
+msgid "Cookie policy settings"
+msgstr ""
+
+#: blocks/cookie-policy/edit.js:139
+msgid "Cookie policy preview"
+msgstr ""
+
+#: blocks/privacy-policy/edit.js:145 blocks/cookie-policy/edit.js:151
+msgid "Using the current site locale"
+msgstr ""
+
+#: blocks/privacy-policy/edit.js:149 blocks/cookie-policy/edit.js:159
+msgid "No additional languages are configured yet. Add them from the plugin settings to manage locale-specific policies."
+msgstr ""
+
+#: blocks/privacy-policy/edit.js:162
+msgid "Owner details, contact references, and data subject rights."
+msgstr ""
+
+#: blocks/privacy-policy/edit.js:167
+msgid "Legal bases and processing purposes grouped by service categories."
+msgstr ""
+
+#: blocks/privacy-policy/edit.js:172
+msgid "Automatic updates include detected services and consent revision notes."
+msgstr ""
+
+#: blocks/cookie-policy/edit.js:144
+msgid "This block prints the generated cookie policy on the front-end. Configure the language to review locale-specific content while editing."
+msgstr ""
+
+#: blocks/cookie-policy/edit.js:170
+msgid "Service overview, legal bases, and retention for each category."
+msgstr ""
+
+#: blocks/cookie-policy/edit.js:175
+msgid "Cookie tables are rendered automatically from detected services."
+msgstr ""
+
+#: blocks/cookie-policy/edit.js:180
+msgid "Visitors see language-specific contacts and owner details."
+msgstr ""
+
+#: blocks/cookie-preferences/edit.js:144
+msgid "Cookie preferences settings"
+msgstr ""
+
+#: blocks/cookie-preferences/edit.js:148
+msgid "Button label"
+msgstr ""
+
+#: blocks/cookie-preferences/edit.js:156
+msgid "Accessibility description"
+msgstr ""
+
+#: blocks/cookie-preferences/edit.js:159
+msgid "Announced by assistive technologies when the button receives focus."
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:158
+msgid "Cookie banner settings"
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:207 blocks/cookie-banner/edit.js:231
+msgid "Floating panel"
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:206 blocks/cookie-banner/edit.js:232
+msgid "Full-width bar"
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:251
+msgid "Always display this banner instance"
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:256
+msgid "Force the banner to render even if the visitor has already provided consent."
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:263
+msgid "Cookie banner preview"
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:140
+msgid "Sample banner title"
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:144
+msgid "Update the banner texts from the plugin settings to preview them here."
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:283
+msgid "Save the plugin settings after editing banner content to preview the actual copy for each language."
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:298
+msgid "Forced display enabled"
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:308
+msgid "No additional languages are configured yet. Add them from the plugin settings to customise the banner per locale."
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:317
+msgid "Forced display bypasses the automatic hide behaviour. Confirm the banner placement remains accessible across devices."
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:145
+msgid "Accept"
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:146
+msgid "Reject"
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:268
+msgid "Use the inspector controls to review layout, position, and language overrides before publishing the banner."
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:336
+msgid "Floating panels anchor near a corner whereas bars stretch across the viewport edge."
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:344
+msgid "Language overrides let you review translated banner texts without switching the editor UI."
+msgstr ""
+
+#: blocks/cookie-banner/edit.js:352
+msgid "Forced display keeps the banner visible when manually embedding it alongside other content."
+msgstr ""
+
+#: blocks/cookie-preferences/edit.js:181
+msgid "Cookie preferences preview"
+msgstr ""
+
+#: blocks/cookie-preferences/edit.js:187
+msgid "The block renders a button that opens the cookie preferences modal so visitors can change their choices."
+msgstr ""
+
+#: blocks/cookie-preferences/edit.js:197
+msgid "No additional languages are configured yet. Add them from the plugin settings to customize button text per locale."
+msgstr ""
+
+#: blocks/cookie-preferences/edit.js:219
+msgid "On the front-end the button receives focus styles that meet AA contrast requirements."
+msgstr ""
+
+#: blocks/cookie-preferences/edit.js:227
+msgid "Screen readers announce the accessibility description before opening the modal."
+msgstr ""
+
+#: blocks/cookie-preferences/edit.js:235
+msgid "The modal displays a summary of the last recorded consent for additional context."
+msgstr ""

--- a/fp-privacy-cookie-policy/readme.txt
+++ b/fp-privacy-cookie-policy/readme.txt
@@ -1,0 +1,63 @@
+=== FP Privacy and Cookie Policy ===
+Contributors: francescopasseri
+Tags: privacy, cookies, consent, gdpr, consent mode
+Requires at least: 6.2
+Tested up to: 6.6
+Requires PHP: 7.4
+Stable tag: 0.1.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+A comprehensive GDPR/ePrivacy consent manager with Google Consent Mode v2, auto-generated privacy/cookie policies, consent logging, REST + WP-CLI tools, and Gutenberg blocks (no build step).
+
+== Description ==
+
+FP Privacy and Cookie Policy combines privacy notice automation with a fully accessible cookie banner, granular consent storage, Google Consent Mode v2, dataLayer hooks, and developer tooling. The plugin is build-tool free (pure ES5) and supports multisite installs, CSV exports, REST endpoints, and WP-CLI commands.
+
+= Highlights =
+
+* GDPR-friendly banner with floating/bar layouts, palette syncing, preview mode, and accessible modal controls.
+* Consent registry with hashed IP, retention policies, CSV exports, and 30-day summaries.
+* Auto-detected services (GA4, GTM, Meta Pixel, Hotjar, reCAPTCHA, YouTube, Matomo, TikTok, etc.) feeding localized privacy/cookie policy templates.
+* Google Consent Mode v2 defaults/updates plus `fp-consent-change` CustomEvent and `dataLayer` push.
+* Shortcodes, template tags, and four Gutenberg blocks (Privacy Policy, Cookie Policy, Preferences Button, Cookie Banner).
+* WP-CLI: status, recreate, cleanup, CSV export, settings import/export, detector, policy regeneration.
+* REST API namespace `fp-privacy/v1` with endpoints for consent submission and summaries.
+* Multisite support with automatic provisioning on activation and `wpmu_new_blog`.
+* Extensive hooks (`fp_consent_update`, `fp_privacy_services_registry`, etc.) and filters for customization.
+
+== Installation ==
+
+1. Upload the `fp-privacy-cookie-policy` directory to `/wp-content/plugins/`.
+2. Activate through the **Plugins** menu (or network activate on multisite).
+3. Configure languages, banner content, palette, Consent Mode defaults, and controller/DPO details under **Privacy & Cookie → Settings**.
+4. Review/regenerate the privacy and cookie policies via **Privacy & Cookie → Policy editor**.
+5. Monitor events in **Privacy & Cookie → Consent log** and export CSVs if required.
+
+== Frequently Asked Questions ==
+
+= Does the banner log IP addresses? =
+
+IP addresses are hashed with a constant salt (`FP_PRIVACY_IP_SALT`). No clear IP data is stored.
+
+= Can I customize detected services? =
+
+Yes. Use the `fp_privacy_services_registry` filter to add or override detection callbacks, providers, and cookie lists.
+
+= How do I force users to reconfirm consent? =
+
+Use the "Reset consent (bump revision)" button in **Privacy & Cookie → Settings** or call `wp fp-privacy regenerate --bump-revision` via WP-CLI. Increasing the revision invalidates stored consent and re-triggers the banner.
+
+= Where do I find GTM examples? =
+
+See the quick guide screen inside the plugin and the repository `README.md` for sample dataLayer usage and Consent Mode integration notes.
+
+== Changelog ==
+
+= 0.1.0 =
+* Initial alpha release with banner, consent registry, CSV export, policy detector/generator, WP-CLI, REST API, Google Consent Mode v2, shortcodes, Gutenberg blocks, multisite support, and i18n.
+
+== Upgrade Notice ==
+
+= 0.1.0 =
+First release. Configure banner settings and review generated policies after upgrading.

--- a/fp-privacy-cookie-policy/src/Admin/ConsentLogTable.php
+++ b/fp-privacy-cookie-policy/src/Admin/ConsentLogTable.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * Consent log admin page.
+ *
+ * @package FP\Privacy\Admin
+ */
+
+namespace FP\Privacy\Admin;
+
+use FP\Privacy\Consent\LogModel;
+use FP\Privacy\Utils\Options;
+
+/**
+ * Displays consent log entries.
+ */
+class ConsentLogTable {
+/**
+ * Log model.
+ *
+ * @var LogModel
+ */
+private $log_model;
+
+/**
+ * Options handler.
+ *
+ * @var Options
+ */
+private $options;
+
+/**
+ * Constructor.
+ *
+ * @param LogModel $log_model Log model.
+ * @param Options  $options   Options.
+ */
+public function __construct( LogModel $log_model, Options $options ) {
+$this->log_model = $log_model;
+$this->options   = $options;
+}
+
+/**
+ * Hooks.
+ *
+ * @return void
+ */
+public function hooks() {
+\add_action( 'fp_privacy_admin_page_consent_log', array( $this, 'render_page' ) );
+	\add_action( 'admin_post_fp_privacy_export_csv', array( $this, 'handle_export_csv' ) );
+}
+
+/**
+ * Render admin page.
+ *
+ * @return void
+ */
+public function render_page() {
+if ( ! \current_user_can( 'manage_options' ) ) {
+\wp_die( \esc_html__( 'Permission denied.', 'fp-privacy' ) );
+}
+
+$paged    = isset( $_GET['paged'] ) ? max( 1, (int) $_GET['paged'] ) : 1;
+$per_page = 50;
+$args     = array(
+'paged'    => $paged,
+'per_page' => $per_page,
+'event'    => isset( $_GET['event'] ) ? \sanitize_text_field( \wp_unslash( $_GET['event'] ) ) : '',
+'search'   => isset( $_GET['s'] ) ? \sanitize_text_field( \wp_unslash( $_GET['s'] ) ) : '',
+'from'     => isset( $_GET['from'] ) ? \sanitize_text_field( \wp_unslash( $_GET['from'] ) ) : '',
+'to'       => isset( $_GET['to'] ) ? \sanitize_text_field( \wp_unslash( $_GET['to'] ) ) : '',
+);
+
+$entries = $this->log_model->query( $args );
+$total   = $this->log_model->count( $args );
+$summary = $this->log_model->summary_last_30_days();
+$pages   = (int) ceil( $total / $per_page );
+
+$pagination_args = array(
+	'page' => 'fp-privacy-consent-log',
+);
+
+$export_args = array(
+	'action'   => 'fp_privacy_export_csv',
+	'_wpnonce' => \wp_create_nonce( 'fp_privacy_export_csv' ),
+);
+
+foreach ( array( 'event' => 'event', 'search' => 's', 'from' => 'from', 'to' => 'to' ) as $key => $query_key ) {
+	if ( ! empty( $args[ $key ] ) ) {
+		$pagination_args[ $query_key ] = $args[ $key ];
+		$export_args[ $query_key ]      = $args[ $key ];
+	}
+}
+
+$pagination_base = \esc_url_raw( \add_query_arg( array_merge( $pagination_args, array( 'paged' => '%#%' ) ), \admin_url( 'admin.php' ) ) );
+$export_url      = \add_query_arg( $export_args, \admin_url( 'admin-post.php' ) );
+
+?>
+<div class="wrap fp-privacy-consent-log">
+<h1><?php \esc_html_e( 'Consent log', 'fp-privacy' ); ?></h1>
+<p><?php \esc_html_e( 'Review consent events and export them for compliance.', 'fp-privacy' ); ?></p>
+
+<form method="get" class="fp-privacy-filters">
+<input type="hidden" name="page" value="fp-privacy-consent-log" />
+<input type="search" name="s" value="<?php echo \esc_attr( $args['search'] ); ?>" placeholder="<?php \esc_attr_e( 'Search by ID, user agent or language', 'fp-privacy' ); ?>" />
+<select name="event">
+<option value=""><?php \esc_html_e( 'All events', 'fp-privacy' ); ?></option>
+<?php foreach ( array( 'accept_all', 'reject_all', 'consent', 'reset', 'revision_bump' ) as $event ) : ?>
+<option value="<?php echo \esc_attr( $event ); ?>" <?php\selected( $args['event'], $event ); ?>><?php echo \esc_html( ucfirst( str_replace( '_', ' ', $event ) ) ); ?></option>
+<?php endforeach; ?>
+</select>
+<label><?php \esc_html_e( 'From', 'fp-privacy' ); ?> <input type="date" name="from" value="<?php echo \esc_attr( $args['from'] ); ?>" /></label>
+<label><?php \esc_html_e( 'To', 'fp-privacy' ); ?> <input type="date" name="to" value="<?php echo \esc_attr( $args['to'] ); ?>" /></label>
+<button type="submit" class="button"><?php \esc_html_e( 'Filter', 'fp-privacy' ); ?></button>
+<a href="<?php echo \esc_url( $export_url ); ?>" class="button button-secondary"><?php \esc_html_e( 'Export CSV', 'fp-privacy' ); ?></a>
+</form>
+
+<div class="fp-privacy-summary">
+<h2><?php \esc_html_e( 'Last 30 days overview', 'fp-privacy' ); ?></h2>
+<ul>
+<?php foreach ( $summary as $event => $count ) : ?>
+<li><strong><?php echo \esc_html( ucfirst( str_replace( '_', ' ', $event ) ) ); ?>:</strong> <?php echo (int) $count; ?></li>
+<?php endforeach; ?>
+</ul>
+</div>
+
+<table class="widefat fp-privacy-log-table">
+<thead>
+<tr>
+<th><?php \esc_html_e( 'Date', 'fp-privacy' ); ?></th>
+<th><?php \esc_html_e( 'Event', 'fp-privacy' ); ?></th>
+<th><?php \esc_html_e( 'Consent ID', 'fp-privacy' ); ?></th>
+<th><?php \esc_html_e( 'Language', 'fp-privacy' ); ?></th>
+<th><?php \esc_html_e( 'Revision', 'fp-privacy' ); ?></th>
+<th><?php \esc_html_e( 'User agent', 'fp-privacy' ); ?></th>
+<th><?php \esc_html_e( 'States', 'fp-privacy' ); ?></th>
+</tr>
+</thead>
+<tbody>
+<?php if ( empty( $entries ) ) : ?>
+<tr><td colspan="7"><?php \esc_html_e( 'No entries found.', 'fp-privacy' ); ?></td></tr>
+<?php else : ?>
+<?php foreach ( $entries as $entry ) : ?>
+<tr>
+<td><?php echo \esc_html( \mysql2date( \get_option( 'date_format' ) . ' ' . \get_option( 'time_format' ), $entry['created_at'] ) ); ?></td>
+<td><span class="fp-privacy-event fp-privacy-event-<?php echo \esc_attr( $entry['event'] ); ?>"><?php echo \esc_html( ucfirst( str_replace( '_', ' ', $entry['event'] ) ) ); ?></span></td>
+<td><?php echo \esc_html( $entry['consent_id'] ); ?></td>
+<td><?php echo \esc_html( $entry['lang'] ); ?></td>
+<td><?php echo (int) $entry['rev']; ?></td>
+<td><code><?php echo \esc_html( mb_strimwidth( $entry['ua'], 0, 80, '…', 'UTF-8' ) ); ?></code></td>
+<td><details><summary><?php \esc_html_e( 'View', 'fp-privacy' ); ?></summary><pre><?php echo \esc_html( \wp_json_encode( $entry['states'], JSON_PRETTY_PRINT ) ); ?></pre></details></td>
+</tr>
+<?php endforeach; ?>
+<?php endif; ?>
+</tbody>
+</table>
+
+<?php if ( $pages > 1 ) : ?>
+<div class="tablenav">
+<div class="tablenav-pages">
+<?php echo \paginate_links( array(
+'current' => $paged,
+'total'   => $pages,
+'base'    => $pagination_base,
+'format'  => '',
+) ); ?>
+</div>
+</div>
+<?php endif; ?>
+</div>
+<?php
+}
+
+/**
+ * Handle CSV export.
+ *
+ * @return void
+ */
+public function handle_export_csv() {
+	if ( ! \current_user_can( 'manage_options' ) ) {
+	\wp_die( \esc_html__( 'Permission denied.', 'fp-privacy' ) );
+	}
+
+	\check_admin_referer( 'fp_privacy_export_csv' );
+
+	$args = array(
+		'event' => isset( $_GET['event'] ) ? \sanitize_text_field( \wp_unslash( $_GET['event'] ) ) : '',
+		'search' => isset( $_GET['s'] ) ? \sanitize_text_field( \wp_unslash( $_GET['s'] ) ) : '',
+		'from'   => isset( $_GET['from'] ) ? \sanitize_text_field( \wp_unslash( $_GET['from'] ) ) : '',
+		'to'     => isset( $_GET['to'] ) ? \sanitize_text_field( \wp_unslash( $_GET['to'] ) ) : '',
+	);
+
+	$batch = (int) \apply_filters( 'fp_privacy_csv_export_batch_size', 1000 );
+	if ( $batch < 1 ) {
+		$batch = 1000;
+	}
+
+	$filename = 'fp-consent-log-' . \gmdate( 'Ymd-His' ) . '.csv';
+	$handle   = \fopen( 'php://output', 'w' );
+
+	if ( false === $handle ) {
+	\wp_die( \esc_html__( 'Unable to open export stream.', 'fp-privacy' ) );
+	}
+
+	\nocache_headers();
+	\header( 'Content-Type: text/csv; charset=utf-8' );
+	\header( 'Content-Disposition: attachment; filename="' . \sanitize_file_name( $filename ) . '"' );
+
+	\fputcsv( $handle, array( 'consent_id', 'event', 'lang', 'rev', 'created_at', 'ip_hash', 'user_agent', 'states' ) );
+
+	$page = 1;
+
+	while ( true ) {
+		$entries = $this->log_model->query( array_merge( $args, array( 'paged' => $page, 'per_page' => $batch ) ) );
+
+		if ( empty( $entries ) ) {
+			break;
+		}
+
+		foreach ( $entries as $entry ) {
+			\fputcsv(
+				$handle,
+				array(
+					$entry['consent_id'],
+					$entry['event'],
+					$entry['lang'],
+					(int) $entry['rev'],
+					$entry['created_at'],
+					$entry['ip_hash'],
+					$entry['ua'],
+					\wp_json_encode( $entry['states'] ),
+				)
+			);
+		}
+
+		$page++;
+		if ( count( $entries ) < $batch ) {
+			break;
+		}
+	}
+
+	\fclose( $handle );
+	exit;
+}
+}

--- a/fp-privacy-cookie-policy/src/Admin/DashboardWidget.php
+++ b/fp-privacy-cookie-policy/src/Admin/DashboardWidget.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Dashboard widget.
+ *
+ * @package FP\Privacy\Admin
+ */
+
+namespace FP\Privacy\Admin;
+
+use FP\Privacy\Consent\LogModel;
+
+/**
+ * Adds dashboard widget summary.
+ */
+class DashboardWidget {
+/**
+ * Log model.
+ *
+ * @var LogModel
+ */
+private $log_model;
+
+/**
+ * Constructor.
+ *
+ * @param LogModel $log_model Log model.
+ */
+public function __construct( LogModel $log_model ) {
+$this->log_model = $log_model;
+}
+
+/**
+ * Hooks.
+ *
+ * @return void
+ */
+public function hooks() {
+\add_action( 'wp_dashboard_setup', array( $this, 'register_widget' ) );
+}
+
+/**
+ * Register widget.
+ *
+ * @return void
+ */
+public function register_widget() {
+\wp_add_dashboard_widget( 'fp_privacy_dashboard', \__( 'Privacy & Cookie overview', 'fp-privacy' ), array( $this, 'render_widget' ) );
+}
+
+/**
+ * Render widget content.
+ *
+ * @return void
+ */
+public function render_widget() {
+$summary = $this->log_model->summary_last_30_days();
+$total   = array_sum( $summary );
+?>
+<p><strong><?php \esc_html_e( 'Total events in the last 30 days:', 'fp-privacy' ); ?></strong> <?php echo (int) $total; ?></p>
+<ul>
+<?php foreach ( $summary as $event => $count ) : ?>
+<li><?php echo \esc_html( ucfirst( str_replace( '_', ' ', $event ) ) ); ?>: <?php echo (int) $count; ?></li>
+<?php endforeach; ?>
+</ul>
+<p><a href="<?php echo \esc_url( admin_url( 'admin.php?page=fp-privacy-consent-log' ) ); ?>" class="button"><?php \esc_html_e( 'View consent log', 'fp-privacy' ); ?></a></p>
+<?php
+}
+}

--- a/fp-privacy-cookie-policy/src/Admin/Menu.php
+++ b/fp-privacy-cookie-policy/src/Admin/Menu.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Admin menu.
+ *
+ * @package FP\Privacy\Admin
+ */
+
+namespace FP\Privacy\Admin;
+
+/**
+ * Registers admin menu structure.
+ */
+class Menu {
+const MENU_SLUG = 'fp-privacy';
+
+/**
+ * Hooks.
+ *
+ * @return void
+ */
+public function hooks() {
+\\add_action( 'admin_menu', array( $this, 'register_menu' ) );
+}
+
+/**
+ * Register menu and subpages.
+ *
+ * @return void
+ */
+public function register_menu() {
+if ( ! \\current_user_can( 'manage_options' ) ) {
+return;
+}
+
+\\add_menu_page(
+\__( 'Privacy & Cookie', 'fp-privacy' ),
+\__( 'Privacy & Cookie', 'fp-privacy' ),
+'manage_options',
+self::MENU_SLUG,
+array( $this, 'render_settings_page' ),
+'dashicons-shield-alt',
+59
+);
+
+\\add_submenu_page(
+self::MENU_SLUG,
+\__( 'Settings', 'fp-privacy' ),
+\__( 'Settings', 'fp-privacy' ),
+'manage_options',
+self::MENU_SLUG,
+array( $this, 'render_settings_page' )
+);
+
+\\add_submenu_page(
+self::MENU_SLUG,
+\__( 'Policy editor', 'fp-privacy' ),
+\__( 'Policy editor', 'fp-privacy' ),
+'manage_options',
+'fp-privacy-policy-editor',
+array( $this, 'render_policy_editor' )
+);
+
+\\add_submenu_page(
+self::MENU_SLUG,
+\__( 'Consent log', 'fp-privacy' ),
+\__( 'Consent log', 'fp-privacy' ),
+'manage_options',
+'fp-privacy-consent-log',
+array( $this, 'render_consent_log' )
+);
+
+\\add_submenu_page(
+self::MENU_SLUG,
+\__( 'Tools', 'fp-privacy' ),
+\__( 'Tools', 'fp-privacy' ),
+'manage_options',
+'fp-privacy-tools',
+array( $this, 'render_tools' )
+);
+
+\\add_submenu_page(
+self::MENU_SLUG,
+\__( 'Quick guide', 'fp-privacy' ),
+\__( 'Quick guide', 'fp-privacy' ),
+'manage_options',
+'fp-privacy-guide',
+array( $this, 'render_guide' )
+);
+}
+
+/**
+ * Render settings page.
+ *
+ * @return void
+ */
+public function render_settings_page() {
+\\do_action( 'fp_privacy_admin_page_settings' );
+}
+
+/**
+ * Render policy editor page.
+ *
+ * @return void
+ */
+public function render_policy_editor() {
+\\do_action( 'fp_privacy_admin_page_policy_editor' );
+}
+
+/**
+ * Render consent log page.
+ *
+ * @return void
+ */
+public function render_consent_log() {
+\\do_action( 'fp_privacy_admin_page_consent_log' );
+}
+
+/**
+ * Render tools page.
+ *
+ * @return void
+ */
+public function render_tools() {
+\\do_action( 'fp_privacy_admin_page_tools' );
+}
+
+/**
+ * Render guide page.
+ *
+ * @return void
+ */
+public function render_guide() {
+\\do_action( 'fp_privacy_admin_page_guide' );
+}
+}

--- a/fp-privacy-cookie-policy/src/Admin/PolicyEditor.php
+++ b/fp-privacy-cookie-policy/src/Admin/PolicyEditor.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * Policy editor page.
+ *
+ * @package FP\Privacy\Admin
+ */
+
+namespace FP\Privacy\Admin;
+
+use FP\Privacy\Utils\Options;
+
+/**
+ * Handles policy editing and regeneration.
+ */
+class PolicyEditor {
+/**
+ * Options handler.
+ *
+ * @var Options
+ */
+private $options;
+
+/**
+ * Generator.
+ *
+ * @var PolicyGenerator
+ */
+private $generator;
+
+/**
+ * Constructor.
+ *
+ * @param Options         $options   Options handler.
+ * @param PolicyGenerator $generator Generator.
+ */
+public function __construct( Options $options, PolicyGenerator $generator ) {
+$this->options   = $options;
+$this->generator = $generator;
+}
+
+/**
+ * Hooks.
+ *
+ * @return void
+ */
+public function hooks() {
+\add_action( 'fp_privacy_admin_page_policy_editor', array( $this, 'render_page' ) );
+\add_action( 'admin_post_fp_privacy_save_policy', array( $this, 'handle_save' ) );
+\add_action( 'admin_post_fp_privacy_regenerate_policy', array( $this, 'handle_regenerate' ) );
+}
+
+/**
+ * Render page.
+ *
+ * @return void
+ */
+public function render_page() {
+if ( ! \current_user_can( 'manage_options' ) ) {
+\wp_die( \esc_html__( 'Permission denied.', 'fp-privacy' ) );
+}
+
+$languages = $this->options->get_languages();
+if ( empty( $languages ) ) {
+$languages = array( \get_locale() );
+}
+
+$privacy_posts = array();
+$cookie_posts  = array();
+
+foreach ( $languages as $language ) {
+    $privacy_id              = $this->options->get_page_id( 'privacy_policy', $language );
+    $cookie_id               = $this->options->get_page_id( 'cookie_policy', $language );
+    $privacy_posts[ $language ] = $privacy_id ? \get_post( $privacy_id ) : null;
+    $cookie_posts[ $language ]  = $cookie_id ? \get_post( $cookie_id ) : null;
+}
+?>
+<div class="wrap fp-privacy-policy-editor">
+<h1><?php \esc_html_e( 'Policy editor', 'fp-privacy' ); ?></h1>
+<p><?php \esc_html_e( 'Customize the generated documents or regenerate them using the detector.', 'fp-privacy' ); ?></p>
+
+<form method="post" action="<?php echo \esc_url( \admin_url( 'admin-post.php' ) ); ?>">
+<?php \wp_nonce_field( 'fp_privacy_save_policy', 'fp_privacy_policy_nonce' ); ?>
+<input type="hidden" name="action" value="fp_privacy_save_policy" />
+
+<?php foreach ( $languages as $index => $language ) :
+    $lang_key = \sanitize_key( $language . '_' . $index );
+    $privacy  = $privacy_posts[ $language ];
+    $cookie   = $cookie_posts[ $language ];
+    ?>
+    <div class="fp-privacy-language-section">
+        <h2><?php echo \esc_html( \sprintf( \__( 'Privacy policy (%s)', 'fp-privacy' ), $language ) ); ?></h2>
+        <?php \wp_editor( $privacy ? $privacy->post_content : '', 'fp_privacy_policy_' . $lang_key, array( 'textarea_name' => 'privacy_content[' . \esc_attr( $language ) . ']', 'textarea_rows' => 12 ) ); ?>
+
+        <h2><?php echo \esc_html( \sprintf( \__( 'Cookie policy (%s)', 'fp-privacy' ), $language ) ); ?></h2>
+        <?php \wp_editor( $cookie ? $cookie->post_content : '', 'fp_privacy_cookie_' . $lang_key, array( 'textarea_name' => 'cookie_content[' . \esc_attr( $language ) . ']', 'textarea_rows' => 12 ) ); ?>
+    </div>
+<?php endforeach; ?>
+
+<?php \submit_button( \__( 'Save policies', 'fp-privacy' ) ); ?>
+</form>
+
+<form method="post" action="<?php echo \esc_url( \admin_url( 'admin-post.php' ) ); ?>" class="fp-privacy-regenerate">
+<?php \wp_nonce_field( 'fp_privacy_regenerate_policy', 'fp_privacy_regenerate_nonce' ); ?>
+<input type="hidden" name="action" value="fp_privacy_regenerate_policy" />
+<?php \submit_button( \__( 'Detect integrations and regenerate', 'fp-privacy' ), 'secondary' ); ?>
+</form>
+
+<?php $diff = $this->get_diff_preview( $languages, $privacy_posts, $cookie_posts ); ?>
+<?php if ( $diff ) : ?>
+<h2><?php \esc_html_e( 'Differences between generated templates and current documents', 'fp-privacy' ); ?></h2>
+<div class="fp-privacy-diff"><?php echo $diff; ?></div>
+<?php endif; ?>
+</div>
+<?php
+}
+
+
+/**
+ * Handle manual save.
+ *
+ * @return void
+ */
+public function handle_save() {
+if ( ! \current_user_can( 'manage_options' ) ) {
+\wp_die( \esc_html__( 'Permission denied.', 'fp-privacy' ) );
+}
+
+\check_admin_referer( 'fp_privacy_save_policy', 'fp_privacy_policy_nonce' );
+
+$privacy_contents = isset( $_POST['privacy_content'] ) ? \wp_unslash( $_POST['privacy_content'] ) : array();
+$cookie_contents  = isset( $_POST['cookie_content'] ) ? \wp_unslash( $_POST['cookie_content'] ) : array();
+
+$languages = $this->options->get_languages();
+if ( empty( $languages ) ) {
+$languages = array( \get_locale() );
+}
+
+foreach ( $languages as $language ) {
+    $language    = $this->options->normalize_language( $language );
+    $privacy_id  = $this->options->get_page_id( 'privacy_policy', $language );
+    $cookie_id   = $this->options->get_page_id( 'cookie_policy', $language );
+    $privacy_body = isset( $privacy_contents[ $language ] ) ? $privacy_contents[ $language ] : '';
+    $cookie_body  = isset( $cookie_contents[ $language ] ) ? $cookie_contents[ $language ] : '';
+
+    if ( $privacy_id ) {
+        \wp_update_post(
+            array(
+                'ID'           => $privacy_id,
+                'post_content' => $privacy_body,
+            )
+        );
+    }
+
+    if ( $cookie_id ) {
+        \wp_update_post(
+            array(
+                'ID'           => $cookie_id,
+                'post_content' => $cookie_body,
+            )
+        );
+    }
+}
+
+\wp_safe_redirect( \add_query_arg( 'policy-updated', '1', \wp_get_referer() ) );
+exit;
+}
+
+
+/**
+ * Handle regeneration.
+ *
+ * @return void
+ */
+public function handle_regenerate() {
+if ( ! \current_user_can( 'manage_options' ) ) {
+\wp_die( \esc_html__( 'Permission denied.', 'fp-privacy' ) );
+}
+
+\check_admin_referer( 'fp_privacy_regenerate_policy', 'fp_privacy_regenerate_nonce' );
+
+$this->options->ensure_pages_exist();
+
+$languages = $this->options->get_languages();
+if ( empty( $languages ) ) {
+$languages = array( \get_locale() );
+}
+
+foreach ( $languages as $language ) {
+    $language    = $this->options->normalize_language( $language );
+    $privacy_id  = $this->options->get_page_id( 'privacy_policy', $language );
+    $cookie_id   = $this->options->get_page_id( 'cookie_policy', $language );
+
+    $privacy = $this->generator->generate_privacy_policy( $language );
+    $cookie  = $this->generator->generate_cookie_policy( $language );
+
+    if ( $privacy_id ) {
+        \wp_update_post(
+            array(
+                'ID'           => $privacy_id,
+                'post_content' => $privacy,
+            )
+        );
+    }
+
+    if ( $cookie_id ) {
+        \wp_update_post(
+            array(
+                'ID'           => $cookie_id,
+                'post_content' => $cookie,
+            )
+        );
+    }
+}
+
+$this->options->bump_revision();
+$this->options->set( $this->options->all() );
+
+\wp_safe_redirect( \add_query_arg( 'policy-regenerated', '1', \wp_get_referer() ) );
+exit;
+}
+
+
+    /**
+     * Diff preview.
+     *
+     * @param array<int, string>        $languages     Active languages.
+     * @param array<string, \WP_Post?> $privacy_posts Privacy posts keyed by language.
+     * @param array<string, \WP_Post?> $cookie_posts  Cookie posts keyed by language.
+     *
+     * @return string
+     */
+    private function get_diff_preview( array $languages, array $privacy_posts, array $cookie_posts ) {
+$output = '';
+
+foreach ( $languages as $language ) {
+    $language    = $this->options->normalize_language( $language );
+    $privacy_post = isset( $privacy_posts[ $language ] ) ? $privacy_posts[ $language ] : null;
+    $cookie_post  = isset( $cookie_posts[ $language ] ) ? $cookie_posts[ $language ] : null;
+
+    $generated_privacy = $this->generator->generate_privacy_policy( $language );
+    $generated_cookie  = $this->generator->generate_cookie_policy( $language );
+
+    $privacy_current = $privacy_post ? $privacy_post->post_content : '';
+    $cookie_current  = $cookie_post ? $cookie_post->post_content : '';
+
+    $privacy_diff = \wp_text_diff( $privacy_current, $generated_privacy, array( 'title' => \sprintf( \__( 'Privacy policy diff (%s)', 'fp-privacy' ), $language ) ) );
+    $cookie_diff  = \wp_text_diff( $cookie_current, $generated_cookie, array( 'title' => \sprintf( \__( 'Cookie policy diff (%s)', 'fp-privacy' ), $language ) ) );
+
+    $output .= $privacy_diff . $cookie_diff;
+}
+
+return $output;
+}
+
+}

--- a/fp-privacy-cookie-policy/src/Admin/PolicyGenerator.php
+++ b/fp-privacy-cookie-policy/src/Admin/PolicyGenerator.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Policy generator.
+ *
+ * @package FP\Privacy\Admin
+ */
+
+namespace FP\Privacy\Admin;
+
+use FP\Privacy\Integrations\DetectorRegistry;
+use FP\Privacy\Utils\Options;
+use FP\Privacy\Utils\View;
+
+/**
+ * Generates policy contents based on detected services and options.
+ */
+class PolicyGenerator {
+/**
+ * Options handler.
+ *
+ * @var Options
+ */
+private $options;
+
+/**
+ * Detector registry.
+ *
+ * @var DetectorRegistry
+ */
+private $detector;
+
+/**
+ * View renderer.
+ *
+ * @var View
+ */
+private $view;
+
+/**
+ * Constructor.
+ *
+ * @param Options          $options  Options.
+ * @param DetectorRegistry $detector Detector.
+ * @param View             $view     View renderer.
+ */
+public function __construct( Options $options, DetectorRegistry $detector, View $view ) {
+$this->options  = $options;
+$this->detector = $detector;
+$this->view     = $view;
+}
+
+/**
+ * Generate privacy policy HTML.
+ *
+ * @param string $lang Language.
+ *
+ * @return string
+ */
+public function generate_privacy_policy( $lang ) {
+return $this->view->render(
+'privacy-policy.php',
+array(
+'lang'     => $lang,
+'options'  => $this->options->all(),
+'groups'   => $this->group_services(),
+)
+);
+}
+
+/**
+ * Generate cookie policy HTML.
+ *
+ * @param string $lang Language.
+ *
+ * @return string
+ */
+public function generate_cookie_policy( $lang ) {
+return $this->view->render(
+'cookie-policy.php',
+array(
+'lang'     => $lang,
+'options'  => $this->options->all(),
+'groups'   => $this->group_services(),
+)
+);
+}
+
+/**
+ * Get grouped services.
+ *
+ * @return array<string, array<int, array<string, mixed>>>
+ */
+public function group_services() {
+$services = $this->detector->detect_services();
+$groups   = array();
+
+foreach ( $services as $service ) {
+$category = $service['category'];
+if ( ! isset( $groups[ $category ] ) ) {
+$groups[ $category ] = array();
+}
+$groups[ $category ][] = $service;
+}
+
+return $groups;
+}
+
+/**
+ * Export snapshot of services.
+ *
+ * @return array<int, array<string, mixed>>
+ */
+public function snapshot() {
+return $this->detector->detect_services();
+}
+}

--- a/fp-privacy-cookie-policy/src/Admin/Settings.php
+++ b/fp-privacy-cookie-policy/src/Admin/Settings.php
@@ -1,0 +1,428 @@
+<?php
+/**
+ * Settings page.
+ *
+ * @package FP\Privacy\Admin
+ */
+
+namespace FP\Privacy\Admin;
+
+use FP\Privacy\Integrations\DetectorRegistry;
+use FP\Privacy\Admin\PolicyGenerator;
+use FP\Privacy\Utils\Options;
+
+/**
+ * Renders and saves settings.
+ */
+class Settings {
+/**
+ * Options handler.
+ *
+ * @var Options
+ */
+private $options;
+
+/**
+ * Detector registry.
+ *
+ * @var DetectorRegistry
+ */
+private $detector;
+
+/**
+ * Policy generator.
+ *
+ * @var PolicyGenerator
+ */
+private $generator;
+
+/**
+ * Constructor.
+ *
+ * @param Options          $options   Options handler.
+ * @param DetectorRegistry $detector  Detector.
+ * @param PolicyGenerator  $generator Generator.
+ */
+public function __construct( Options $options, DetectorRegistry $detector, PolicyGenerator $generator ) {
+$this->options   = $options;
+$this->detector  = $detector;
+$this->generator = $generator;
+}
+
+/**
+ * Hooks.
+ *
+ * @return void
+ */
+public function hooks() {
+	\add_action( 'fp_privacy_admin_page_settings', array( $this, 'render_page' ) );
+	\add_action( 'fp_privacy_admin_page_tools', array( $this, 'render_tools_page' ) );
+	\add_action( 'fp_privacy_admin_page_guide', array( $this, 'render_guide_page' ) );
+	\add_action( 'admin_post_fp_privacy_save_settings', array( $this, 'handle_save' ) );
+	\add_action( 'admin_post_fp_privacy_bump_revision', array( $this, 'handle_bump_revision' ) );
+	\add_action( 'admin_post_fp_privacy_export_settings', array( $this, 'handle_export_settings' ) );
+	\add_action( 'admin_post_fp_privacy_import_settings', array( $this, 'handle_import_settings' ) );
+	\add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+}
+
+/**
+ * Enqueue admin assets.
+ *
+ * @param string $hook Hook.
+ *
+ * @return void
+ */
+public function enqueue_assets( $hook ) {
+if ( false === strpos( $hook, Menu::MENU_SLUG ) ) {
+return;
+}
+
+\wp_enqueue_style( 'fp-privacy-admin', FP_PRIVACY_PLUGIN_URL . 'assets/css/admin.css', array(), FP_PRIVACY_PLUGIN_VERSION );
+\wp_enqueue_script( 'fp-privacy-admin', FP_PRIVACY_PLUGIN_URL . 'assets/js/admin.js', array( 'jquery' ), FP_PRIVACY_PLUGIN_VERSION, true );
+}
+
+/**
+ * Render settings page.
+ *
+ * @return void
+ */
+public function render_page() {
+if ( ! \current_user_can( 'manage_options' ) ) {
+\wp_die( \esc_html__( 'You do not have permission to access this page.', 'fp-privacy' ) );
+}
+
+$options   = $this->options->all();
+$languages = $options['languages_active'];
+$detected  = $this->detector->detect_services();
+?>
+<div class="wrap fp-privacy-settings">
+<h1><?php \esc_html_e( 'Privacy & Cookie Settings', 'fp-privacy' ); ?></h1>
+<form method="post" action="<?php echo \esc_url( \admin_url( 'admin-post.php' ) ); ?>" class="fp-privacy-settings-form">
+<?php \wp_nonce_field( 'fp_privacy_save_settings', 'fp_privacy_nonce' ); ?>
+<input type="hidden" name="action" value="fp_privacy_save_settings" />
+
+<h2><?php \esc_html_e( 'Languages', 'fp-privacy' ); ?></h2>
+<p class="description"><?php \esc_html_e( 'Provide active languages (comma separated locale codes).', 'fp-privacy' ); ?></p>
+<input type="text" name="languages_active" class="regular-text" value="<?php echo \esc_attr( implode( ',', $languages ) ); ?>" />
+
+<h2><?php \esc_html_e( 'Banner content', 'fp-privacy' ); ?></h2>
+<?php foreach ( $languages as $lang ) :
+$text = isset( $options['banner_texts'][ $lang ] ) ? $options['banner_texts'][ $lang ] : $this->options->get_default_options()['banner_texts'][ \get_locale() ];
+?>
+<div class="fp-privacy-language-panel">
+<h3><?php echo \esc_html( \sprintf( \__( 'Language: %s', 'fp-privacy' ), $lang ) ); ?></h3>
+<label>
+<span><?php \esc_html_e( 'Title', 'fp-privacy' ); ?></span>
+<input type="text" name="banner_texts[<?php echo \esc_attr( $lang ); ?>][title]" value="<?php echo \esc_attr( $text['title'] ); ?>" class="regular-text" />
+</label>
+<label>
+<span><?php \esc_html_e( 'Message', 'fp-privacy' ); ?></span>
+<textarea name="banner_texts[<?php echo \esc_attr( $lang ); ?>][message]" rows="4" class="large-text"><?php echo \esc_textarea( $text['message'] ); ?></textarea>
+</label>
+<label>
+<span><?php \esc_html_e( 'Accept button label', 'fp-privacy' ); ?></span>
+<input type="text" name="banner_texts[<?php echo \esc_attr( $lang ); ?>][btn_accept]" value="<?php echo \esc_attr( $text['btn_accept'] ); ?>" />
+</label>
+<label>
+<span><?php \esc_html_e( 'Reject button label', 'fp-privacy' ); ?></span>
+<input type="text" name="banner_texts[<?php echo \esc_attr( $lang ); ?>][btn_reject]" value="<?php echo \esc_attr( $text['btn_reject'] ); ?>" />
+</label>
+<label>
+<span><?php \esc_html_e( 'Preferences button label', 'fp-privacy' ); ?></span>
+<input type="text" name="banner_texts[<?php echo \esc_attr( $lang ); ?>][btn_prefs]" value="<?php echo \esc_attr( $text['btn_prefs'] ); ?>" />
+</label>
+<label>
+<span><?php \esc_html_e( 'Policy link URL', 'fp-privacy' ); ?></span>
+<input type="url" name="banner_texts[<?php echo \esc_attr( $lang ); ?>][link_policy]" value="<?php echo \esc_attr( $text['link_policy'] ); ?>" class="regular-text" />
+</label>
+</div>
+<?php endforeach; ?>
+
+<h2><?php \esc_html_e( 'Layout', 'fp-privacy' ); ?></h2>
+<div class="fp-privacy-layout">
+<label>
+<span><?php \esc_html_e( 'Display type', 'fp-privacy' ); ?></span>
+<select name="banner_layout[type]">
+<option value="floating" <?php\selected( $options['banner_layout']['type'], 'floating' ); ?>><?php \esc_html_e( 'Floating', 'fp-privacy' ); ?></option>
+<option value="bar" <?php\selected( $options['banner_layout']['type'], 'bar' ); ?>><?php \esc_html_e( 'Bar', 'fp-privacy' ); ?></option>
+</select>
+</label>
+<label>
+<span><?php \esc_html_e( 'Position', 'fp-privacy' ); ?></span>
+<select name="banner_layout[position]">
+<option value="top" <?php\selected( $options['banner_layout']['position'], 'top' ); ?>><?php \esc_html_e( 'Top', 'fp-privacy' ); ?></option>
+<option value="bottom" <?php\selected( $options['banner_layout']['position'], 'bottom' ); ?>><?php \esc_html_e( 'Bottom', 'fp-privacy' ); ?></option>
+</select>
+</label>
+<label>
+<input type="checkbox" name="banner_layout[sync_modal_and_button]" value="1" <?php\checked( $options['banner_layout']['sync_modal_and_button'], true ); ?> />
+<?php \esc_html_e( 'Synchronize modal and button palette', 'fp-privacy' ); ?>
+</label>
+</div>
+
+<h2><?php \esc_html_e( 'Palette', 'fp-privacy' ); ?></h2>
+<div class="fp-privacy-palette">
+<?php foreach ( $options['banner_layout']['palette'] as $key => $color ) : ?>
+<label>
+<span><?php echo \esc_html( ucwords( str_replace( '_', ' ', $key ) ) ); ?></span>
+<input type="color" name="banner_layout[palette][<?php echo \esc_attr( $key ); ?>]" value="<?php echo \esc_attr( $color ); ?>" />
+</label>
+<?php endforeach; ?>
+</div>
+
+<h2><?php \esc_html_e( 'Consent Mode defaults', 'fp-privacy' ); ?></h2>
+<div class="fp-privacy-consent-mode">
+<?php foreach ( $options['consent_mode_defaults'] as $key => $value ) : ?>
+<label>
+<span><?php echo \esc_html( ucwords( str_replace( '_', ' ', $key ) ) ); ?></span>
+<select name="consent_mode_defaults[<?php echo \esc_attr( $key ); ?>]">
+<option value="granted" <?php\selected( $value, 'granted' ); ?>><?php \esc_html_e( 'Granted', 'fp-privacy' ); ?></option>
+<option value="denied" <?php\selected( $value, 'denied' ); ?>><?php \esc_html_e( 'Denied', 'fp-privacy' ); ?></option>
+</select>
+</label>
+<?php endforeach; ?>
+</div>
+
+<h2><?php \esc_html_e( 'Retention & Revision', 'fp-privacy' ); ?></h2>
+<label>
+<span><?php \esc_html_e( 'Retention days', 'fp-privacy' ); ?></span>
+<input type="number" min="1" name="retention_days" value="<?php echo \esc_attr( $options['retention_days'] ); ?>" />
+</label>
+<label>
+<input type="checkbox" name="preview_mode" value="1" <?php\checked( $options['preview_mode'], true ); ?> />
+<?php \esc_html_e( 'Enable preview mode (admins only)', 'fp-privacy' ); ?>
+</label>
+<p><?php echo \esc_html( \sprintf( \__( 'Current consent revision: %d', 'fp-privacy' ), $options['consent_revision'] ) ); ?></p>
+<p><a class="button button-secondary" href="<?php echo \esc_url( \wp_nonce_url( \admin_url( 'admin-post.php?action=fp_privacy_bump_revision' ), 'fp_privacy_bump_revision' ) ); ?>"><?php \esc_html_e( 'Force new consent (bump revision)', 'fp-privacy' ); ?></a></p>
+
+<h2><?php \esc_html_e( 'Controller & DPO', 'fp-privacy' ); ?></h2>
+<div class="fp-privacy-org">
+<label><span><?php \esc_html_e( 'Organization name', 'fp-privacy' ); ?></span><input type="text" name="org_name" value="<?php echo \esc_attr( $options['org_name'] ); ?>" class="regular-text" /></label>
+<label><span><?php \esc_html_e( 'VAT / Tax ID', 'fp-privacy' ); ?></span><input type="text" name="vat" value="<?php echo \esc_attr( $options['vat'] ); ?>" class="regular-text" /></label>
+<label><span><?php \esc_html_e( 'Registered address', 'fp-privacy' ); ?></span><input type="text" name="address" value="<?php echo \esc_attr( $options['address'] ); ?>" class="regular-text" /></label>
+<label><span><?php \esc_html_e( 'DPO name', 'fp-privacy' ); ?></span><input type="text" name="dpo_name" value="<?php echo \esc_attr( $options['dpo_name'] ); ?>" class="regular-text" /></label>
+<label><span><?php \esc_html_e( 'DPO email', 'fp-privacy' ); ?></span><input type="email" name="dpo_email" value="<?php echo \esc_attr( $options['dpo_email'] ); ?>" class="regular-text" /></label>
+<label><span><?php \esc_html_e( 'Privacy contact email', 'fp-privacy' ); ?></span><input type="email" name="privacy_email" value="<?php echo \esc_attr( $options['privacy_email'] ); ?>" class="regular-text" /></label>
+</div>
+
+<?php \submit_button( \__( 'Save settings', 'fp-privacy' ) ); ?>
+</form>
+
+<h2><?php \esc_html_e( 'Detected services', 'fp-privacy' ); ?></h2>
+<table class="widefat fp-privacy-detected">
+<thead>
+<tr>
+<th><?php \esc_html_e( 'Service', 'fp-privacy' ); ?></th>
+<th><?php \esc_html_e( 'Category', 'fp-privacy' ); ?></th>
+<th><?php \esc_html_e( 'Detected', 'fp-privacy' ); ?></th>
+<th><?php \esc_html_e( 'Provider', 'fp-privacy' ); ?></th>
+<th><?php \esc_html_e( 'Cookies', 'fp-privacy' ); ?></th>
+</tr>
+</thead>
+<tbody>
+<?php foreach ( $detected as $service ) : ?>
+<tr>
+<td><?php echo \esc_html( $service['name'] ); ?></td>
+<td><?php echo \esc_html( $service['category'] ); ?></td>
+<td><?php echo $service['detected'] ? '<span class="status-detected">' . \esc_html__( 'Yes', 'fp-privacy' ) . '</span>' : \esc_html__( 'No', 'fp-privacy' ); ?></td>
+<td><?php echo \esc_html( $service['provider'] ); ?></td>
+<td><?php echo \esc_html( implode( ', ', $service['cookies'] ) ); ?></td>
+</tr>
+<?php endforeach; ?>
+</tbody>
+</table>
+
+<p class="description"><?php \esc_html_e( 'Use the policy editor to regenerate your documents after services change.', 'fp-privacy' ); ?></p>
+</div>
+<?php
+}
+
+/**
+ * Render tools page.
+ *
+ * @return void
+ */
+public function render_tools_page() {
+	if ( ! \current_user_can( 'manage_options' ) ) {
+	\wp_die( \esc_html__( 'Permission denied.', 'fp-privacy' ) );
+	}
+
+	?>
+	<div class="wrap fp-privacy-tools">
+		<h1><?php \esc_html_e( 'Tools', 'fp-privacy' ); ?></h1>
+		<p><?php \esc_html_e( 'Export or import configuration, regenerate policies and reset revision.', 'fp-privacy' ); ?></p>
+		<form method="post" action="<?php echo \esc_url( \admin_url( 'admin-post.php' ) ); ?>" class="fp-privacy-tools-export">
+			<?php \wp_nonce_field( 'fp_privacy_export_settings', 'fp_privacy_export_nonce' ); ?>
+			<input type="hidden" name="action" value="fp_privacy_export_settings" />
+			<?php \submit_button( \__( 'Download settings JSON', 'fp-privacy' ), 'secondary' ); ?>
+		</form>
+		<form method="post" action="<?php echo \esc_url( \admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data" class="fp-privacy-tools-import">
+			<?php \wp_nonce_field( 'fp_privacy_import_settings', 'fp_privacy_import_nonce' ); ?>
+			<input type="hidden" name="action" value="fp_privacy_import_settings" />
+			<input type="file" name="settings_file" accept="application/json" required />
+			<?php \submit_button( \__( 'Import settings', 'fp-privacy' ) ); ?>
+		</form>
+		<form method="post" action="<?php echo \esc_url( \admin_url( 'admin-post.php' ) ); ?>" class="fp-privacy-tools-regenerate">
+			<?php \wp_nonce_field( 'fp_privacy_regenerate_policy', 'fp_privacy_regenerate_nonce' ); ?>
+			<input type="hidden" name="action" value="fp_privacy_regenerate_policy" />
+			<?php \submit_button( \__( 'Regenerate policies', 'fp-privacy' ), 'secondary' ); ?>
+		</form>
+		<p><a class="button" href="<?php echo \esc_url( \wp_nonce_url( \admin_url( 'admin-post.php?action=fp_privacy_bump_revision' ), 'fp_privacy_bump_revision' ) ); ?>"><?php \esc_html_e( 'Reset consent (bump revision)', 'fp-privacy' ); ?></a></p>
+	</div>
+	<?php
+}
+
+/**
+ * Render quick guide page.
+ *
+ * @return void
+ */
+public function render_guide_page() {
+	if ( ! \current_user_can( 'manage_options' ) ) {
+	\wp_die( \esc_html__( 'Permission denied.', 'fp-privacy' ) );
+	}
+
+	?>
+	<div class="wrap fp-privacy-guide">
+		<h1><?php \esc_html_e( 'Quick guide', 'fp-privacy' ); ?></h1>
+		<h2><?php \esc_html_e( 'Shortcodes', 'fp-privacy' ); ?></h2>
+		<ul>
+			<li><code>[fp_privacy_policy]</code></li>
+			<li><code>[fp_cookie_policy]</code></li>
+			<li><code>[fp_cookie_preferences]</code></li>
+			<li><code>[fp_cookie_banner]</code></li>
+		</ul>
+		<h2><?php \esc_html_e( 'Blocks', 'fp-privacy' ); ?></h2>
+		<p><?php \esc_html_e( 'Use the Privacy Policy, Cookie Policy, Cookie Preferences and Cookie Banner blocks inside the block editor. Each block mirrors the shortcode output.', 'fp-privacy' ); ?></p>
+		<h2><?php \esc_html_e( 'Hooks', 'fp-privacy' ); ?></h2>
+		<ul>
+			<li><code>fp_consent_update</code></li>
+			<li><code>fp_privacy_settings_imported</code></li>
+			<li><code>fp_privacy_policy_content</code></li>
+			<li><code>fp_cookie_policy_content</code></li>
+		</ul>
+		<h2><?php \esc_html_e( 'Legal notice', 'fp-privacy' ); ?></h2>
+		<p><?php \esc_html_e( 'This plugin provides technical tooling to help comply with privacy regulations. Consult your legal advisor to validate the generated documents.', 'fp-privacy' ); ?></p>
+	</div>
+	<?php
+}
+
+/**
+ * Handle settings export.
+ *
+ * @return void
+ */
+public function handle_export_settings() {
+	if ( ! \current_user_can( 'manage_options' ) ) {
+	\wp_die( \esc_html__( 'Permission denied.', 'fp-privacy' ) );
+	}
+
+	\check_admin_referer( 'fp_privacy_export_settings', 'fp_privacy_export_nonce' );
+
+	$settings = $this->options->all();
+	$filename = 'fp-privacy-settings-' . \gmdate( 'Ymd-His' ) . '.json';
+
+	\nocache_headers();
+	\header( 'Content-Type: application/json; charset=utf-8' );
+	\header( 'Content-Disposition: attachment; filename="' . \sanitize_file_name( $filename ) . '"' );
+
+	echo \wp_json_encode( $settings, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+	exit;
+}
+
+/**
+ * Handle settings import.
+ *
+ * @return void
+ */
+public function handle_import_settings() {
+	if ( ! \current_user_can( 'manage_options' ) ) {
+	\wp_die( \esc_html__( 'Permission denied.', 'fp-privacy' ) );
+	}
+
+	\check_admin_referer( 'fp_privacy_import_settings', 'fp_privacy_import_nonce' );
+
+	$redirect = \wp_get_referer() ? \wp_get_referer() : \admin_url( 'admin.php?page=fp-privacy-tools' );
+
+	if ( empty( $_FILES['settings_file']['tmp_name'] ) || ! \is_uploaded_file( $_FILES['settings_file']['tmp_name'] ) ) {
+	\wp_safe_redirect( \add_query_arg( 'fp-privacy-import', 'missing', $redirect ) );
+	exit;
+	}
+
+	$content = \file_get_contents( $_FILES['settings_file']['tmp_name'] );
+	if ( false === $content ) {
+	\wp_safe_redirect( \add_query_arg( 'fp-privacy-import', 'error', $redirect ) );
+	exit;
+	}
+
+	$data = \json_decode( $content, true );
+	if ( ! is_array( $data ) ) {
+	\wp_safe_redirect( \add_query_arg( 'fp-privacy-import', 'invalid', $redirect ) );
+	exit;
+	}
+
+	$this->options->set( $data );
+	\do_action( 'fp_privacy_settings_imported', $this->options->all() );
+
+	\wp_safe_redirect( \add_query_arg( 'fp-privacy-import', 'success', $redirect ) );
+	exit;
+}
+
+/**
+ * Handle settings save.
+ *
+ * @return void
+ */
+public function handle_save() {
+if ( ! \current_user_can( 'manage_options' ) ) {
+\wp_die( \esc_html__( 'Permission denied.', 'fp-privacy' ) );
+}
+
+\check_admin_referer( 'fp_privacy_save_settings', 'fp_privacy_nonce' );
+
+$languages = isset( $_POST['languages_active'] ) ? array_filter( array_map( 'trim', explode( ',', \wp_unslash( $_POST['languages_active'] ) ) ) ) : array();
+if ( empty( $languages ) ) {
+$languages = array( \get_locale() );
+}
+
+$payload = array(
+'languages_active'      => $languages,
+'banner_texts'          => isset( $_POST['banner_texts'] ) ? \wp_unslash( $_POST['banner_texts'] ) : array(),
+'banner_layout'         => isset( $_POST['banner_layout'] ) ? \wp_unslash( $_POST['banner_layout'] ) : array(),
+'consent_mode_defaults' => isset( $_POST['consent_mode_defaults'] ) ? \wp_unslash( $_POST['consent_mode_defaults'] ) : array(),
+'preview_mode'          => isset( $_POST['preview_mode'] ),
+'org_name'              => isset( $_POST['org_name'] ) ? \wp_unslash( $_POST['org_name'] ) : '',
+'vat'                   => isset( $_POST['vat'] ) ? \wp_unslash( $_POST['vat'] ) : '',
+'address'               => isset( $_POST['address'] ) ? \wp_unslash( $_POST['address'] ) : '',
+'dpo_name'              => isset( $_POST['dpo_name'] ) ? \wp_unslash( $_POST['dpo_name'] ) : '',
+'dpo_email'             => isset( $_POST['dpo_email'] ) ? \wp_unslash( $_POST['dpo_email'] ) : '',
+'privacy_email'         => isset( $_POST['privacy_email'] ) ? \wp_unslash( $_POST['privacy_email'] ) : '',
+'categories'            => $this->options->get( 'categories' ),
+'retention_days'        => isset( $_POST['retention_days'] ) ? (int) $_POST['retention_days'] : $this->options->get( 'retention_days' ),
+);
+
+$this->options->set( $payload );
+
+\wp_safe_redirect( \add_query_arg( 'updated', 'true', \wp_get_referer() ) );
+exit;
+}
+
+/**
+ * Handle revision bump.
+ *
+ * @return void
+ */
+public function handle_bump_revision() {
+if ( ! \current_user_can( 'manage_options' ) ) {
+\wp_die( \esc_html__( 'Permission denied.', 'fp-privacy' ) );
+}
+
+\check_admin_referer( 'fp_privacy_bump_revision' );
+
+$this->options->bump_revision();
+$this->options->set( $this->options->all() );
+
+\wp_safe_redirect( \add_query_arg( 'revision-bumped', '1', \wp_get_referer() ) );
+exit;
+}
+}

--- a/fp-privacy-cookie-policy/src/CLI/Commands.php
+++ b/fp-privacy-cookie-policy/src/CLI/Commands.php
@@ -1,0 +1,242 @@
+<?php
+/**
+ * WP-CLI commands.
+ *
+ * @package FP\Privacy\CLI
+ */
+
+namespace FP\Privacy\CLI;
+
+use FP\Privacy\Consent\Cleanup;
+use FP\Privacy\Consent\LogModel;
+use FP\Privacy\Integrations\DetectorRegistry;
+use FP\Privacy\Admin\PolicyGenerator;
+use FP\Privacy\Utils\Options;
+use WP_CLI;
+use WP_CLI_Command;
+
+/**
+ * Implements fp-privacy CLI commands.
+ */
+class Commands extends WP_CLI_Command {
+/**
+ * Log model.
+ *
+ * @var LogModel
+ */
+private $log_model;
+
+/**
+ * Options handler.
+ *
+ * @var Options
+ */
+private $options;
+
+/**
+ * Generator.
+ *
+ * @var PolicyGenerator
+ */
+private $generator;
+
+/**
+ * Detector registry.
+ *
+ * @var DetectorRegistry
+ */
+private $detector;
+
+/**
+ * Cleanup handler.
+ *
+ * @var Cleanup
+ */
+private $cleanup;
+
+/**
+ * Constructor.
+ *
+ * @param LogModel        $log_model Log model.
+ * @param Options         $options   Options.
+ * @param PolicyGenerator $generator Generator.
+ * @param DetectorRegistry $detector Detector.
+ * @param Cleanup         $cleanup   Cleanup handler.
+ */
+public function __construct( LogModel $log_model, Options $options, PolicyGenerator $generator, DetectorRegistry $detector, Cleanup $cleanup ) {
+$this->log_model = $log_model;
+$this->options   = $options;
+$this->generator = $generator;
+$this->detector  = $detector;
+$this->cleanup   = $cleanup;
+}
+
+/**
+ * Display status information.
+ */
+public function status() {
+$total = $this->log_model->count();
+$summary = $this->log_model->summary_last_30_days();
+WP_CLI::log( 'Consent log table: ' . $this->log_model->get_table() );
+WP_CLI::log( 'Total events: ' . $total );
+foreach ( $summary as $event => $count ) {
+WP_CLI::log( ucfirst( str_replace( '_', ' ', $event ) ) . ': ' . $count );
+}
+$next = \\wp_next_scheduled( 'fp_privacy_cleanup' );
+WP_CLI::log( 'Next cleanup: ' . ( $next ? gmdate( 'c', $next ) : 'not scheduled' ) );
+}
+
+/**
+ * Recreate database table.
+ *
+ * ## OPTIONS
+ *
+ * [--force]
+ * : Drop and recreate the table.
+ */
+public function recreate( $args, $assoc_args ) {
+if ( isset( $assoc_args['force'] ) && $assoc_args['force'] ) {
+global $wpdb;
+$wpdb->query( 'DROP TABLE IF EXISTS ' . $this->log_model->get_table() );
+WP_CLI::warning( 'Existing table dropped.' );
+}
+
+$this->log_model->maybe_create_table();
+if ( ! \\wp_next_scheduled( 'fp_privacy_cleanup' ) ) {
+\\wp_schedule_event( time() + DAY_IN_SECONDS, 'daily', 'fp_privacy_cleanup' );
+}
+WP_CLI::success( 'Consent log table ready.' );
+}
+
+/**
+ * Run cleanup immediately.
+ */
+public function cleanup() {
+$this->cleanup->run();
+WP_CLI::success( 'Cleanup completed.' );
+}
+
+/**
+ * Export CSV.
+ *
+ * ## OPTIONS
+ *
+ * --file=<path>
+ * : Destination file path.
+ */
+public function export( $args, $assoc_args ) {
+if ( empty( $assoc_args['file'] ) ) {
+WP_CLI::error( 'Missing --file parameter.' );
+}
+
+$file = $assoc_args['file'];
+$handle = fopen( $file, 'w' );
+if ( ! $handle ) {
+WP_CLI::error( 'Unable to open file.' );
+}
+
+fputcsv( $handle, array( 'id', 'consent_id', 'event', 'states', 'lang', 'rev', 'created_at' ) );
+$batch_size = (int) \apply_filters( 'fp_privacy_csv_export_batch_size', 1000 );
+$paged = 1;
+
+while ( true ) {
+$entries = $this->log_model->query(
+array(
+'paged'    => $paged,
+'per_page' => $batch_size,
+)
+);
+
+if ( empty( $entries ) ) {
+break;
+}
+
+foreach ( $entries as $entry ) {
+fputcsv( $handle, array( $entry['id'], $entry['consent_id'], $entry['event'], json_encode( $entry['states'] ), $entry['lang'], $entry['rev'], $entry['created_at'] ) );
+}
+
+$paged++;
+}
+
+fclose( $handle );
+WP_CLI::success( 'Export completed: ' . $file );
+}
+
+/**
+ * Export settings to JSON.
+ *
+ * --file=<path>
+ */
+public function settings_export( $args, $assoc_args ) {
+if ( empty( $assoc_args['file'] ) ) {
+WP_CLI::error( 'Missing --file parameter.' );
+}
+
+$file = $assoc_args['file'];
+$written = file_put_contents( $file, \\wp_json_encode( $this->options->all(), JSON_PRETTY_PRINT ) );
+if ( ! $written ) {
+WP_CLI::error( 'Unable to write file.' );
+}
+
+WP_CLI::success( 'Settings exported to ' . $file );
+}
+
+/**
+ * Import settings from JSON.
+ *
+ * --file=<path>
+ */
+public function settings_import( $args, $assoc_args ) {
+if ( empty( $assoc_args['file'] ) || ! file_exists( $assoc_args['file'] ) ) {
+WP_CLI::error( 'File not found.' );
+}
+
+$data = json_decode( file_get_contents( $assoc_args['file'] ), true );
+if ( ! \is_array( $data ) ) {
+WP_CLI::error( 'Invalid JSON file.' );
+}
+
+$this->options->set( $data );
+\\do_action( 'fp_privacy_settings_imported', $this->options->all() );
+
+WP_CLI::success( 'Settings imported.' );
+}
+
+/**
+ * Detect services.
+ */
+public function detect() {
+$services = $this->detector->detect_services();
+foreach ( $services as $service ) {
+WP_CLI::log( sprintf( '%s [%s] - %s', $service['name'], $service['category'], $service['detected'] ? 'detected' : 'not detected' ) );
+}
+}
+
+/**
+ * Regenerate policy documents.
+ *
+ * ## OPTIONS
+ *
+ * [--lang=<lang>]
+ * : Language to use.
+ *
+ * [--bump-revision]
+ * : Increment consent revision after regeneration.
+ */
+public function regenerate( $args, $assoc_args ) {
+$lang = isset( $assoc_args['lang'] ) ? $assoc_args['lang'] : \\get_locale();
+$privacy = $this->generator->generate_privacy_policy( $lang );
+$cookie  = $this->generator->generate_cookie_policy( $lang );
+
+WP_CLI::log( '--- Privacy Policy ---' );
+WP_CLI::log( $privacy );
+WP_CLI::log( '--- Cookie Policy ---' );
+WP_CLI::log( $cookie );
+
+if ( isset( $assoc_args['bump-revision'] ) ) {
+$this->options->bump_revision();
+$this->options->set( $this->options->all() );
+WP_CLI::success( 'Consent revision bumped.' );
+}
+}
+}

--- a/fp-privacy-cookie-policy/src/Consent/Cleanup.php
+++ b/fp-privacy-cookie-policy/src/Consent/Cleanup.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Cleanup handler.
+ *
+ * @package FP\Privacy\Consent
+ */
+
+namespace FP\Privacy\Consent;
+
+use FP\Privacy\Utils\Options;
+
+/**
+ * Handles retention cleanup scheduling and execution.
+ */
+class Cleanup {
+/**
+ * Log model.
+ *
+ * @var LogModel
+ */
+private $log_model;
+
+/**
+ * Options.
+ *
+ * @var Options
+ */
+private $options;
+
+/**
+ * Constructor.
+ *
+ * @param LogModel $log_model Log model.
+ * @param Options  $options   Options.
+ */
+public function __construct( LogModel $log_model, Options $options ) {
+$this->log_model = $log_model;
+$this->options   = $options;
+}
+
+/**
+ * Register hooks.
+ *
+ * @return void
+ */
+public function hooks() {
+\add_action( 'fp_privacy_cleanup', array( $this, 'run' ) );
+}
+
+/**
+ * Execute cleanup.
+ *
+ * @return void
+ */
+public function run() {
+$days = (int) $this->options->get( 'retention_days', 180 );
+$days = $days > 0 ? $days : 180;
+
+$this->log_model->delete_older_than( $days );
+}
+}

--- a/fp-privacy-cookie-policy/src/Consent/ExporterEraser.php
+++ b/fp-privacy-cookie-policy/src/Consent/ExporterEraser.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Privacy exporters and erasers integration.
+ *
+ * @package FP\Privacy\Consent
+ */
+
+namespace FP\Privacy\Consent;
+
+use FP\Privacy\Utils\Options;
+
+/**
+ * Registers exporters and erasers for GDPR tools.
+ */
+class ExporterEraser {
+/**
+ * Log model.
+ *
+ * @var LogModel
+ */
+private $log_model;
+
+/**
+ * Options handler.
+ *
+ * @var Options
+ */
+private $options;
+
+/**
+ * Constructor.
+ *
+ * @param LogModel $log_model Log model.
+ * @param Options  $options   Options.
+ */
+public function __construct( LogModel $log_model, Options $options ) {
+$this->log_model = $log_model;
+$this->options   = $options;
+}
+
+/**
+ * Register hooks.
+ *
+ * @return void
+ */
+public function hooks() {
+\add_filter( 'wp_privacy_personal_data_exporters', array( $this, 'register_exporter' ) );
+\add_filter( 'wp_privacy_personal_data_erasers', array( $this, 'register_eraser' ) );
+}
+
+/**
+ * Register exporter callback.
+ *
+ * @param array<string, mixed> $exporters Exporters.
+ *
+ * @return array<string, mixed>
+ */
+public function register_exporter( $exporters ) {
+$exporters['fp-privacy-consent'] = array(
+'exporter_friendly_name' => \__( 'FP Privacy consent log', 'fp-privacy' ),
+'callback'               => array( $this, 'export_personal_data' ),
+);
+
+return $exporters;
+}
+
+/**
+ * Register eraser callback.
+ *
+ * @param array<string, mixed> $erasers Erasers.
+ *
+ * @return array<string, mixed>
+ */
+public function register_eraser( $erasers ) {
+$erasers['fp-privacy-consent'] = array(
+'eraser_friendly_name' => \__( 'FP Privacy consent log', 'fp-privacy' ),
+'callback'             => array( $this, 'erase_personal_data' ),
+);
+
+return $erasers;
+}
+
+/**
+ * Export personal data.
+ *
+ * @param string $email Email or consent id.
+ * @param int    $page  Page number.
+ *
+ * @return array<string, mixed>
+ */
+public function export_personal_data( $email, $page ) {
+global $wpdb;
+
+$page      = max( 1, (int) $page );
+$per_page  = 100;
+$offset    = ( $page - 1 ) * $per_page;
+$consent_id = \\sanitize_text_field( $email );
+
+$results = $wpdb->get_results(
+$wpdb->prepare(
+"SELECT * FROM {$this->log_model->get_table()} WHERE consent_id = %s ORDER BY created_at ASC LIMIT %d OFFSET %d",
+$consent_id,
+$per_page,
+$offset
+),
+ARRAY_A
+);
+
+$data = array();
+
+foreach ( $results as $row ) {
+$data[] = array(
+'name'  => \__( 'Consent Log Entry', 'fp-privacy' ),
+'value' => \\wp_json_encode( array(
+'event'   => $row['event'],
+'lang'    => $row['lang'],
+'rev'     => (int) $row['rev'],
+'time'    => $row['created_at'],
+'states'  => \\json_decode( $row['states'], true ),
+'user_agent' => $row['ua'],
+) ),
+);
+}
+
+$done = count( $results ) < $per_page;
+
+return array(
+'data' => $data,
+'done' => $done,
+);
+}
+
+/**
+ * Erase personal data.
+ *
+ * @param string $email Email or consent id.
+ * @param int    $page  Page number.
+ *
+ * @return array<string, mixed>
+ */
+public function erase_personal_data( $email, $page ) {
+global $wpdb;
+
+$page       = max( 1, (int) $page );
+$per_page   = 100;
+$offset     = ( $page - 1 ) * $per_page;
+$consent_id = \\sanitize_text_field( $email );
+
+$rows = $wpdb->get_results(
+$wpdb->prepare(
+"SELECT id FROM {$this->log_model->get_table()} WHERE consent_id = %s ORDER BY created_at ASC LIMIT %d OFFSET %d",
+$consent_id,
+$per_page,
+$offset
+),
+ARRAY_A
+);
+
+$ids = \\wp_list_pluck( $rows, 'id' );
+
+$removed = 0;
+if ( $ids ) {
+$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+$wpdb->query( $wpdb->prepare( "DELETE FROM {$this->log_model->get_table()} WHERE id IN ({$placeholders})", $ids ) );
+$removed = count( $ids );
+}
+
+$done = count( $rows ) < $per_page;
+
+return array(
+'items_removed'  => $removed > 0,
+'items_retained' => false,
+'messages'       => array(),
+'done'           => $done,
+);
+}
+}

--- a/fp-privacy-cookie-policy/src/Consent/LogModel.php
+++ b/fp-privacy-cookie-policy/src/Consent/LogModel.php
@@ -1,0 +1,306 @@
+<?php
+/**
+ * Consent log model.
+ *
+ * @package FP\Privacy\Consent
+ */
+
+namespace FP\Privacy\Consent;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+
+/**
+ * Handles persistence for consent log.
+ */
+class LogModel {
+/**
+ * Table name cache.
+ *
+ * @var string
+ */
+private $table;
+
+/**
+ * Constructor.
+ */
+public function __construct() {
+global $wpdb;
+$this->table = $wpdb->prefix . 'fp_consent_log';
+}
+
+/**
+ * Maybe create table.
+ *
+ * @return void
+ */
+public function maybe_create_table() {
+global $wpdb;
+
+$charset_collate = $wpdb->get_charset_collate();
+$table           = $this->table;
+
+$sql = "CREATE TABLE {$table} (
+id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+consent_id VARCHAR(64) NOT NULL,
+event ENUM('accept_all','reject_all','consent','reset','revision_bump') NOT NULL,
+states LONGTEXT NULL,
+ip_hash CHAR(64) NOT NULL,
+ua VARCHAR(255) NULL,
+lang VARCHAR(16) NULL,
+rev INT NOT NULL DEFAULT 1,
+created_at DATETIME NOT NULL,
+PRIMARY KEY  (id),
+KEY event (event),
+KEY created_at (created_at),
+KEY rev (rev)
+) {$charset_collate};";
+
+require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+\dbDelta( $sql );
+}
+
+/**
+ * Insert log entry.
+ *
+ * @param array<string, mixed> $data Data.
+ *
+ * @return bool
+ */
+public function insert( array $data ) {
+global $wpdb;
+
+$defaults = array(
+'consent_id' => '',
+'event'      => 'consent',
+'states'     => '{}',
+'ip_hash'    => '',
+'ua'         => '',
+'lang'       => '',
+'rev'        => 1,
+'created_at' => \current_time( 'mysql', true ),
+);
+
+$data = \\wp_parse_args( $data, $defaults );
+$data = array(
+'consent_id' => \\sanitize_text_field( $data['consent_id'] ),
+'event'      => in_array( $data['event'], array( 'accept_all', 'reject_all', 'consent', 'reset', 'revision_bump' ), true ) ? $data['event'] : 'consent',
+'states'     => \\wp_json_encode( $this->ensure_states( $data['states'] ) ),
+'ip_hash'    => \\sanitize_text_field( $data['ip_hash'] ),
+'ua'         => \\sanitize_text_field( $data['ua'] ),
+'lang'       => \\sanitize_text_field( $data['lang'] ),
+'rev'        => (int) $data['rev'],
+'created_at' => $this->sanitize_datetime( $data['created_at'] ),
+);
+
+return (bool) $wpdb->insert( $this->table, $data );
+}
+
+/**
+ * Get paginated entries.
+ *
+ * @param array<string, mixed> $args Args.
+ *
+ * @return array<int, array<string, mixed>>
+ */
+public function query( array $args = array() ) {
+global $wpdb;
+
+$defaults = array(
+'paged'      => 1,
+'per_page'   => 50,
+'event'      => '',
+'search'     => '',
+'from'       => '',
+'to'         => '',
+);
+
+$args = \\wp_parse_args( $args, $defaults );
+
+$where  = 'WHERE 1=1';
+$params = array();
+
+if ( $args['event'] ) {
+$where   .= ' AND event = %s';
+$params[] = $args['event'];
+}
+
+if ( $args['search'] ) {
+$like     = '%' . $wpdb->esc_like( $args['search'] ) . '%';
+$where   .= ' AND (consent_id LIKE %s OR ua LIKE %s OR lang LIKE %s)';
+$params[] = $like;
+$params[] = $like;
+$params[] = $like;
+}
+
+if ( $args['from'] ) {
+$where   .= ' AND created_at >= %s';
+$params[] = $this->sanitize_datetime( $args['from'] );
+}
+
+if ( $args['to'] ) {
+$where   .= ' AND created_at <= %s';
+$params[] = $this->sanitize_datetime( $args['to'] );
+}
+
+$limit  = (int) $args['per_page'];
+$offset = ( max( 1, (int) $args['paged'] ) - 1 ) * $limit;
+
+$sql = $wpdb->prepare(
+"SELECT * FROM {$this->table} {$where} ORDER BY created_at DESC LIMIT %d OFFSET %d",
+array_merge( $params, array( $limit, $offset ) )
+);
+
+$results = $wpdb->get_results( $sql, ARRAY_A );
+
+return array_map(
+function ( $row ) {
+$row['states'] = \json_decode( $row['states'], true );
+return $row;
+},
+$results
+);
+}
+
+/**
+ * Count entries.
+ *
+ * @param array<string, mixed> $args Args.
+ *
+ * @return int
+ */
+public function count( array $args = array() ) {
+global $wpdb;
+
+$defaults = array(
+'event'  => '',
+'search' => '',
+'from'   => '',
+'to'     => '',
+);
+$args = \\wp_parse_args( $args, $defaults );
+
+$where  = 'WHERE 1=1';
+$params = array();
+
+if ( $args['event'] ) {
+$where   .= ' AND event = %s';
+$params[] = $args['event'];
+}
+
+if ( $args['search'] ) {
+$like     = '%' . $wpdb->esc_like( $args['search'] ) . '%';
+$where   .= ' AND (consent_id LIKE %s OR ua LIKE %s OR lang LIKE %s)';
+$params[] = $like;
+$params[] = $like;
+$params[] = $like;
+}
+
+if ( $args['from'] ) {
+$where   .= ' AND created_at >= %s';
+$params[] = $this->sanitize_datetime( $args['from'] );
+}
+
+if ( $args['to'] ) {
+$where   .= ' AND created_at <= %s';
+$params[] = $this->sanitize_datetime( $args['to'] );
+}
+
+$sql = $wpdb->prepare( "SELECT COUNT(*) FROM {$this->table} {$where}", $params );
+
+return (int) $wpdb->get_var( $sql );
+}
+
+/**
+ * Delete records older than retention days.
+ *
+ * @param int $days Days.
+ *
+ * @return int
+ */
+public function delete_older_than( $days ) {
+global $wpdb;
+
+$threshold = \\gmdate( 'Y-m-d H:i:s', time() - ( (int) $days * DAY_IN_SECONDS ) );
+
+return (int) $wpdb->query( $wpdb->prepare( "DELETE FROM {$this->table} WHERE created_at < %s", $threshold ) );
+}
+
+/**
+ * Summary per event last 30 days.
+ *
+ * @return array<string, int>
+ */
+public function summary_last_30_days() {
+global $wpdb;
+
+$from = \\gmdate( 'Y-m-d H:i:s', time() - ( 30 * DAY_IN_SECONDS ) );
+
+$rows = $wpdb->get_results(
+$wpdb->prepare( "SELECT event, COUNT(*) as total FROM {$this->table} WHERE created_at >= %s GROUP BY event", $from ),
+ARRAY_A
+);
+
+$summary = array(
+'accept_all' => 0,
+'reject_all' => 0,
+'consent'    => 0,
+'reset'      => 0,
+'revision_bump' => 0,
+);
+
+foreach ( $rows as $row ) {
+$summary[ $row['event'] ] = (int) $row['total'];
+}
+
+return $summary;
+}
+
+/**
+ * Get table name.
+ *
+ * @return string
+ */
+public function get_table() {
+return $this->table;
+}
+
+/**
+ * Ensure states array.
+ *
+ * @param mixed $states States.
+ *
+ * @return array<string, mixed>
+ */
+private function ensure_states( $states ) {
+if ( \is_array( $states ) ) {
+return $states;
+}
+
+if ( \is_string( $states ) ) {
+$decoded = \json_decode( $states, true );
+if ( \is_array( $decoded ) ) {
+return $decoded;
+}
+}
+
+return array();
+}
+
+/**
+ * Sanitize datetime string.
+ *
+ * @param string $date Date string.
+ *
+ * @return string
+ */
+private function sanitize_datetime( $date ) {
+try {
+$dt = new DateTimeImmutable( $date, new DateTimeZone( 'UTC' ) );
+return $dt->format( 'Y-m-d H:i:s' );
+} catch ( Exception $e ) {
+return \\gmdate( 'Y-m-d H:i:s' );
+}
+}
+}

--- a/fp-privacy-cookie-policy/src/Frontend/Banner.php
+++ b/fp-privacy-cookie-policy/src/Frontend/Banner.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Frontend banner.
+ *
+ * @package FP\Privacy\Frontend
+ */
+
+namespace FP\Privacy\Frontend;
+
+use FP\Privacy\Utils\Options;
+
+/**
+ * Handles banner rendering and assets.
+ */
+class Banner {
+/**
+ * Options handler.
+ *
+ * @var Options
+ */
+private $options;
+
+/**
+ * Consent state.
+ *
+ * @var ConsentState
+ */
+private $state;
+
+/**
+ * Constructor.
+ *
+ * @param Options      $options Options.
+ * @param ConsentState $state   Consent state.
+ */
+public function __construct( Options $options, ConsentState $state ) {
+$this->options = $options;
+$this->state   = $state;
+}
+
+/**
+ * Hooks.
+ *
+ * @return void
+ */
+public function hooks() {
+\add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+\add_action( 'wp_footer', array( $this, 'render_banner' ) );
+}
+
+/**
+ * Enqueue assets when necessary.
+ *
+ * @return void
+ */
+public function enqueue_assets() {
+$lang      = \\determine_locale();
+$state     = $this->state->get_frontend_state( $lang );
+$should    = $state['state']['should_display'];
+$preview   = $state['state']['preview_mode'];
+$shortcode = \\apply_filters( 'fp_privacy_force_enqueue_banner', false );
+
+if ( ! $should && ! $preview && ! $shortcode ) {
+return;
+}
+
+$handle = 'fp-privacy-banner';
+\\wp_register_style( $handle, FP_PRIVACY_PLUGIN_URL . 'assets/css/banner.css', array(), FP_PRIVACY_PLUGIN_VERSION );
+\\wp_register_script( $handle, FP_PRIVACY_PLUGIN_URL . 'assets/js/banner.js', array(), FP_PRIVACY_PLUGIN_VERSION, true );
+\\wp_register_script( 'fp-privacy-consent-mode', FP_PRIVACY_PLUGIN_URL . 'assets/js/consent-mode.js', array(), FP_PRIVACY_PLUGIN_VERSION, true );
+
+\\wp_enqueue_style( $handle );
+\\wp_add_inline_style( $handle, $this->build_palette_css( $state['layout']['palette'] ) );
+
+\\wp_enqueue_script( 'fp-privacy-consent-mode' );
+\\wp_enqueue_script( $handle );
+
+\\wp_localize_script(
+$handle,
+'FP_PRIVACY_DATA',
+array(
+'ajaxUrl'   => \\admin_url( 'admin-ajax.php' ),
+'nonce'     => \\wp_create_nonce( 'fp-privacy-consent' ),
+'options'   => $state,
+'cookie'    => array(
+'name'     => ConsentState::COOKIE_NAME,
+'duration' => (int) \\apply_filters( 'fp_privacy_cookie_duration_days', 180 ),
+),
+'rest'      => array(
+'url'   => \\esc_url_raw( \\rest_url( 'fp-privacy/v1/consent' ) ),
+'nonce' => \\wp_create_nonce( 'wp_rest' ),
+),
+)
+);
+}
+
+/**
+ * Render banner container.
+ *
+ * @return void
+ */
+public function render_banner() {
+echo '<div id="fp-privacy-banner-root" aria-live="polite"></div>';
+}
+
+/**
+ * Build palette CSS variables.
+ *
+ * @param array<string, string> $palette Palette.
+ *
+ * @return string
+ */
+private function build_palette_css( $palette ) {
+$css = ':root {';
+foreach ( $palette as $key => $value ) {
+$css .= '--fp-privacy-' . \\sanitize_key( $key ) . ':' . \sanitize_hex_color( $value ) . ';';
+}
+$css .= '}';
+
+return $css;
+}
+}

--- a/fp-privacy-cookie-policy/src/Frontend/Blocks.php
+++ b/fp-privacy-cookie-policy/src/Frontend/Blocks.php
@@ -1,0 +1,399 @@
+<?php
+/**
+ * Block registration.
+ *
+ * @package FP\Privacy\Frontend
+ */
+
+namespace FP\Privacy\Frontend;
+
+use FP\Privacy\Utils\Options;
+
+/**
+ * Registers Gutenberg blocks.
+ */
+class Blocks {
+    /**
+     * Options handler.
+     *
+     * @var Options
+     */
+    private $options;
+
+    /**
+     * Tracks localized editor scripts.
+     *
+     * @var array<string, bool>
+     */
+    private $localized = array();
+
+    /**
+     * Constructor.
+     *
+     * @param Options $options Options.
+     */
+    public function __construct( Options $options ) {
+        $this->options = $options;
+    }
+
+    /**
+     * Hooks.
+     *
+     * @return void
+     */
+    public function hooks() {
+        \add_action( 'init', array( $this, 'register_blocks' ) );
+    }
+
+    /**
+     * Register blocks.
+     *
+     * @return void
+     */
+    public function register_blocks() {
+        $blocks = array(
+            'privacy-policy'     => array( $this, 'render_privacy_policy_block' ),
+            'cookie-policy'      => array( $this, 'render_cookie_policy_block' ),
+            'cookie-preferences' => array( $this, 'render_preferences_block' ),
+            'cookie-banner'      => array( $this, 'render_banner_block' ),
+        );
+
+        foreach ( $blocks as $slug => $callback ) {
+            $dir = FP_PRIVACY_PLUGIN_PATH . 'blocks/' . $slug;
+
+            if ( ! file_exists( $dir . '/block.json' ) ) {
+                continue;
+            }
+
+            $this->register_block_assets( $slug );
+
+            $type = \register_block_type(
+                $dir . '/block.json',
+                array(
+                    'render_callback' => $callback,
+                )
+            );
+
+            if ( $type instanceof \WP_Block_Type ) {
+                $this->maybe_localize_languages( $slug, $type->editor_script );
+            }
+        }
+    }
+
+    /**
+     * Render privacy policy block.
+     *
+     * @param array<string, mixed> $attributes Attributes.
+     *
+     * @return string
+     */
+    public function render_privacy_policy_block( $attributes ) {
+        $lang = isset( $attributes['lang'] ) ? \sanitize_text_field( $attributes['lang'] ) : \get_locale();
+
+        return \do_shortcode( '[fp_privacy_policy lang="' . \esc_attr( $lang ) . '"]' );
+    }
+
+    /**
+     * Register block assets for a given slug.
+     *
+     * @param string $slug Block slug.
+     *
+     * @return void
+     */
+    private function register_block_assets( $slug ) {
+        $handles = array(
+            'privacy-policy'     => array(
+                'script' => 'fp-privacy-privacy-policy-block-editor',
+                'style'  => 'fp-privacy-privacy-policy-block-editor-style',
+            ),
+            'cookie-policy'      => array(
+                'script' => 'fp-privacy-cookie-policy-block-editor',
+                'style'  => 'fp-privacy-cookie-policy-block-editor-style',
+            ),
+            'cookie-preferences' => array(
+                'script' => 'fp-privacy-cookie-preferences-block-editor',
+                'style'  => 'fp-privacy-cookie-preferences-block-editor-style',
+            ),
+            'cookie-banner'      => array(
+                'script' => 'fp-privacy-cookie-banner-block-editor',
+                'style'  => 'fp-privacy-cookie-banner-block-editor-style',
+            ),
+        );
+
+        if ( ! isset( $handles[ $slug ] ) ) {
+            return;
+        }
+
+        $dir_path = FP_PRIVACY_PLUGIN_PATH . 'blocks/' . $slug . '/';
+        $dir_url  = FP_PRIVACY_PLUGIN_URL . 'blocks/' . $slug . '/';
+
+        $script_handle = $handles[ $slug ]['script'];
+        $style_handle  = $handles[ $slug ]['style'];
+
+        if ( ! \wp_script_is( $script_handle, 'registered' ) && file_exists( $dir_path . 'edit.js' ) ) {
+            \wp_register_script(
+                $script_handle,
+                $dir_url . 'edit.js',
+                array( 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-components', 'wp-block-editor' ),
+                FP_PRIVACY_PLUGIN_VERSION,
+                true
+            );
+        }
+
+        if ( ! \wp_style_is( $style_handle, 'registered' ) && file_exists( $dir_path . 'style.css' ) ) {
+            \wp_register_style(
+                $style_handle,
+                $dir_url . 'style.css',
+                array(),
+                FP_PRIVACY_PLUGIN_VERSION
+            );
+        }
+    }
+
+    /**
+     * Localize available languages into block editor script.
+     *
+     * @param string $slug   Block slug.
+     * @param string $handle Script handle.
+     *
+     * @return void
+     */
+    private function maybe_localize_languages( $slug, $handle ) {
+        $supported = array( 'privacy-policy', 'cookie-policy', 'cookie-preferences', 'cookie-banner' );
+
+        if ( ! in_array( $slug, $supported, true ) ) {
+            return;
+        }
+
+        if ( empty( $handle ) || isset( $this->localized[ $handle ] ) ) {
+            return;
+        }
+
+        if ( ! \wp_script_is( $handle, 'registered' ) ) {
+            return;
+        }
+
+        $languages = array();
+        $active    = $this->options->get_languages();
+
+        foreach ( $active as $code ) {
+            $normalized = $this->options->normalize_language( $code );
+            if ( '' === $normalized ) {
+                continue;
+            }
+
+            $languages[] = array(
+                'code'  => $normalized,
+                'label' => $this->format_language_label( $normalized ),
+            );
+        }
+
+        if ( empty( $languages ) ) {
+            $fallback = $this->options->normalize_language( \get_locale() );
+            $languages[] = array(
+                'code'  => $fallback,
+                'label' => $this->format_language_label( $fallback ),
+            );
+        }
+
+        $script = 'window.fpPrivacyBlockData = window.fpPrivacyBlockData || {};' .
+            'window.fpPrivacyBlockData.languages = ' . \wp_json_encode( $languages ) . ';';
+
+        if ( 'cookie-banner' === $slug ) {
+            $preview = $this->get_banner_preview_data( $languages );
+
+            if ( ! empty( $preview ) ) {
+                $script .= 'window.fpPrivacyBlockData.bannerPreview = ' . \wp_json_encode( $preview ) . ';';
+            }
+        }
+
+        \wp_add_inline_script( $handle, $script, 'before' );
+
+        $this->localized[ $handle ] = true;
+    }
+
+    /**
+     * Build preview data for banner texts.
+     *
+     * @param array<int, array<string, string>> $languages Registered languages list.
+     *
+     * @return array<string, array<string, string>>
+     */
+    private function get_banner_preview_data( array $languages ) {
+        $preview = array();
+
+        if ( empty( $languages ) ) {
+            $languages[] = array(
+                'code' => $this->options->normalize_language( \get_locale() ),
+            );
+        }
+
+        foreach ( $languages as $language ) {
+            if ( empty( $language['code'] ) ) {
+                continue;
+            }
+
+            $code  = $this->options->normalize_language( $language['code'] );
+            $texts = $this->options->get_banner_text( $code );
+
+            $preview[ $code ] = array(
+                'title'   => $this->prepare_preview_text( $texts['title'] ?? '' ),
+                'message' => $this->prepare_preview_text( $texts['message'] ?? '' ),
+                'accept'  => $this->prepare_preview_text( $texts['btn_accept'] ?? '' ),
+                'reject'  => $this->prepare_preview_text( $texts['btn_reject'] ?? '' ),
+                'prefs'   => $this->prepare_preview_text( $texts['btn_prefs'] ?? '' ),
+            );
+        }
+
+        return $preview;
+    }
+
+    /**
+     * Clean preview text for editor usage.
+     *
+     * @param string $text Raw text.
+     *
+     * @return string
+     */
+    private function prepare_preview_text( $text ) {
+        $clean = \wp_strip_all_tags( (string) $text );
+
+        $clean = \trim( \html_entity_decode( $clean, ENT_QUOTES, \get_bloginfo( 'charset' ) ?: 'UTF-8' ) );
+
+        if ( '' === $clean ) {
+            return '';
+        }
+
+        if ( \function_exists( 'mb_strlen' ) && \function_exists( 'mb_substr' ) ) {
+            if ( \mb_strlen( $clean, 'UTF-8' ) > 320 ) {
+                $clean = \rtrim( \mb_substr( $clean, 0, 317, 'UTF-8' ) ) . '…';
+            }
+        } elseif ( \strlen( $clean ) > 320 ) {
+            $clean = \rtrim( \substr( $clean, 0, 317 ) ) . '…';
+        }
+
+        return $clean;
+    }
+
+    /**
+     * Build a human readable label for the locale.
+     *
+     * @param string $code Locale code.
+     *
+     * @return string
+     */
+    private function format_language_label( $code ) {
+        $label = $code;
+        $locale = str_replace( '_', '-', $code );
+
+        if ( class_exists( '\\Locale' ) ) {
+            try {
+                $display = \Locale::getDisplayName( $locale, $locale );
+                if ( $display ) {
+                    $label = \ucwords( $display );
+                }
+            } catch ( \Throwable $e ) {
+                // Fallback to the code when intl is not available.
+            }
+        }
+
+        return $label;
+    }
+
+    /**
+     * Render cookie policy block.
+     *
+     * @param array<string, mixed> $attributes Attributes.
+     *
+     * @return string
+     */
+    public function render_cookie_policy_block( $attributes ) {
+        $lang = isset( $attributes['lang'] ) ? \sanitize_text_field( $attributes['lang'] ) : \get_locale();
+
+        return \do_shortcode( '[fp_cookie_policy lang="' . \esc_attr( $lang ) . '"]' );
+    }
+
+    /**
+     * Render preferences block.
+     *
+     * @param array<string, mixed> $attributes Attributes.
+     *
+     * @return string
+     */
+    public function render_preferences_block( $attributes ) {
+        $label = isset( $attributes['label'] ) && '' !== \trim( (string) $attributes['label'] )
+            ? \sanitize_text_field( $attributes['label'] )
+            : \__( 'Manage cookie preferences', 'fp-privacy' );
+
+        $description = isset( $attributes['description'] ) && '' !== \trim( (string) $attributes['description'] )
+            ? \sanitize_text_field( $attributes['description'] )
+            : '';
+
+        $lang = isset( $attributes['lang'] ) && '' !== \trim( (string) $attributes['lang'] )
+            ? \preg_replace( '/[^A-Za-z0-9_\\-]/', '', $attributes['lang'] )
+            : '';
+
+        $atts = array(
+            'label' => \esc_attr( $label ),
+        );
+
+        if ( '' !== $description ) {
+            $atts['description'] = \esc_attr( $description );
+        }
+
+        if ( '' !== $lang ) {
+            $atts['lang'] = \esc_attr( $lang );
+        }
+
+        $attr_string = '';
+
+        foreach ( $atts as $key => $value ) {
+            $attr_string .= \sprintf( ' %s="%s"', $key, $value );
+        }
+
+        return \do_shortcode( '[fp_cookie_preferences' . $attr_string . ']' );
+    }
+
+    /**
+     * Render banner block.
+     *
+     * @param array<string, mixed> $attributes Attributes.
+     *
+     * @return string
+     */
+    public function render_banner_block( $attributes ) {
+        $attrs = array();
+
+        $layout = isset( $attributes['layoutType'] ) ? $attributes['layoutType'] : '';
+        $position = isset( $attributes['position'] ) ? $attributes['position'] : '';
+        $lang = isset( $attributes['lang'] ) ? $attributes['lang'] : '';
+
+        if ( 'bar' === $layout ) {
+            $attrs['type'] = 'bar';
+        } elseif ( 'floating' === $layout ) {
+            $attrs['type'] = 'floating';
+        }
+
+        if ( 'top' === $position ) {
+            $attrs['position'] = 'top';
+        } elseif ( 'bottom' === $position ) {
+            $attrs['position'] = 'bottom';
+        }
+
+        if ( \is_string( $lang ) && '' !== \trim( $lang ) ) {
+            $attrs['lang'] = \preg_replace( '/[^A-Za-z0-9_\\-]/', '', $lang );
+        }
+
+        if ( ! empty( $attributes['forceDisplay'] ) ) {
+            $attrs['force'] = '1';
+        }
+
+        $attr_string = '';
+
+        foreach ( $attrs as $key => $value ) {
+            $attr_string .= \sprintf( ' %s="%s"', $key, \esc_attr( $value ) );
+        }
+
+        return \do_shortcode( '[fp_cookie_banner' . $attr_string . ']' );
+    }
+}

--- a/fp-privacy-cookie-policy/src/Frontend/ConsentState.php
+++ b/fp-privacy-cookie-policy/src/Frontend/ConsentState.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * Consent state manager.
+ *
+ * @package FP\Privacy\Frontend
+ */
+
+namespace FP\Privacy\Frontend;
+
+use FP\Privacy\Consent\LogModel;
+use FP\Privacy\Utils\Options;
+
+/**
+ * Handles cookie persistence and logging of consent events.
+ */
+class ConsentState {
+const COOKIE_NAME = 'fp_consent_state_id';
+
+/**
+ * Options handler.
+ *
+ * @var Options
+ */
+private $options;
+
+/**
+ * Log model.
+ *
+ * @var LogModel
+ */
+private $log_model;
+
+/**
+ * Constructor.
+ *
+ * @param Options  $options   Options handler.
+ * @param LogModel $log_model Log model.
+ */
+public function __construct( Options $options, LogModel $log_model ) {
+$this->options   = $options;
+$this->log_model = $log_model;
+}
+
+/**
+ * Get frontend state for a language.
+ *
+ * @param string $lang Language.
+ *
+ * @return array<string, mixed>
+ */
+    public function get_frontend_state( $lang ) {
+        $lang       = $this->options->normalize_language( $lang );
+        $cookie     = $this->get_cookie_payload();
+        $revision   = (int) $this->options->get( 'consent_revision', 1 );
+        $preview    = (bool) $this->options->get( 'preview_mode', false );
+        $needs_consent = $preview || empty( $cookie['id'] ) || ( (int) $cookie['rev'] < $revision );
+
+        $states = array(
+            'categories'     => array(),
+            'consent_id'     => $cookie['id'],
+            'revision'       => $revision,
+            'should_display' => $needs_consent,
+            'preview_mode'   => $preview,
+            'lang'           => $lang,
+        );
+
+        if ( ! $needs_consent ) {
+            $record = $this->log_model->query(
+                array(
+'paged'    => 1,
+'per_page' => 1,
+'event'    => 'consent',
+'from'     => '',
+'to'       => '',
+'search'   => $cookie['id'],
+)
+);
+if ( $record ) {
+$states['categories'] = $record[0]['states'];
+$states['last_event'] = $record[0]['created_at'];
+            }
+        }
+
+        $text       = $this->options->get_banner_text( $lang );
+        $categories = $this->options->get_categories_for_language( $lang );
+
+        return array(
+            'texts'     => $text,
+            'layout'    => $this->options->get( 'banner_layout' ),
+            'categories'=> $categories,
+            'state'     => $states,
+            'mode'      => $this->options->get( 'consent_mode_defaults' ),
+        );
+    }
+
+/**
+ * Save consent event.
+ *
+ * @param string               $event  Event.
+ * @param array<string, mixed> $states States.
+ * @param string               $lang   Language.
+ *
+ * @return array<string, mixed>
+ */
+public function save_event( $event, array $states, $lang ) {
+$preview = (bool) $this->options->get( 'preview_mode', false );
+$cookie  = $this->get_cookie_payload();
+
+if ( empty( $cookie['id'] ) ) {
+$cookie['id'] = $this->generate_consent_id();
+}
+
+$revision = (int) $this->options->get( 'consent_revision', 1 );
+$cookie['rev'] = $revision;
+
+if ( ! $preview ) {
+$this->log_model->insert(
+array(
+'consent_id' => $cookie['id'],
+'event'      => $event,
+'states'     => $states,
+'ip_hash'    => $this->get_ip_hash(),
+'ua'         => $this->get_user_agent(),
+'lang'       => $lang,
+'rev'        => $revision,
+)
+);
+
+\do_action( 'fp_consent_update', $states, $event, $revision );
+}
+
+$this->set_cookie( $cookie['id'], $revision );
+
+return array(
+'consent_id' => $cookie['id'],
+'revision'   => $revision,
+'preview'    => $preview,
+);
+}
+
+/**
+ * Reset consent state.
+ *
+ * @return void
+ */
+public function reset() {
+$cookie = $this->get_cookie_payload();
+$this->set_cookie( '', 0, time() - HOUR_IN_SECONDS );
+
+if ( $cookie['id'] ) {
+$this->log_model->insert(
+array(
+'consent_id' => $cookie['id'],
+'event'      => 'reset',
+'ip_hash'    => $this->get_ip_hash(),
+'ua'         => $this->get_user_agent(),
+'lang'       => \get_locale(),
+'rev'        => (int) $this->options->get( 'consent_revision', 1 ),
+)
+);
+}
+}
+
+/**
+ * Get cookie payload.
+ *
+ * @return array{id:string,rev:int}
+ */
+private function get_cookie_payload() {
+if ( empty( $_COOKIE[ self::COOKIE_NAME ] ) ) {
+return array(
+'id'  => '',
+'rev' => 0,
+);
+}
+
+$value = \sanitize_text_field( \wp_unslash( $_COOKIE[ self::COOKIE_NAME ] ) );
+
+$parts = explode( '|', $value );
+
+return array(
+'id'  => isset( $parts[0] ) ? $parts[0] : '',
+'rev' => isset( $parts[1] ) ? (int) $parts[1] : 0,
+);
+}
+
+/**
+ * Set cookie.
+ *
+ * @param string $id    Consent ID.
+ * @param int    $rev   Revision.
+ * @param int    $time  Expiration timestamp.
+ *
+ * @return void
+ */
+private function set_cookie( $id, $rev, $time = 0 ) {
+if ( headers_sent() ) {
+return;
+}
+
+$days = (int) \apply_filters( 'fp_privacy_cookie_duration_days', 180 );
+$days = $days > 0 ? $days : 180;
+
+if ( ! $time ) {
+$time = time() + ( $days * DAY_IN_SECONDS );
+}
+
+$secure = \is_ssl();
+$value  = $id ? $id . '|' . (int) $rev : '';
+$options = array(
+'expires'  => $time,
+'path'     => COOKIEPATH ? COOKIEPATH : '/',
+'domain'   => COOKIE_DOMAIN,
+'secure'   => $secure,
+'httponly' => false,
+'samesite' => 'Lax',
+);
+
+\setcookie( self::COOKIE_NAME, $value, $options );
+
+if ( COOKIEPATH !== SITECOOKIEPATH ) {
+$options['path'] = SITECOOKIEPATH ? SITECOOKIEPATH : '/';
+\setcookie( self::COOKIE_NAME, $value, $options );
+}
+}
+
+/**
+ * Generate unique consent identifier.
+ *
+ * @return string
+ */
+private function generate_consent_id() {
+try {
+return bin2hex( random_bytes( 16 ) );
+} catch ( \Exception $e ) {
+return uniqid( 'fpconsent', true );
+}
+}
+
+/**
+ * Get hashed IP.
+ *
+ * @return string
+ */
+private function get_ip_hash() {
+$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? \sanitize_text_field( \wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+return hash( 'sha256', $ip . '|' . FP_PRIVACY_IP_SALT );
+}
+
+/**
+ * Get user agent.
+ *
+ * @return string
+ */
+private function get_user_agent() {
+return isset( $_SERVER['HTTP_USER_AGENT'] ) ? \sanitize_text_field( \wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
+}
+}

--- a/fp-privacy-cookie-policy/src/Frontend/Shortcodes.php
+++ b/fp-privacy-cookie-policy/src/Frontend/Shortcodes.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * Shortcodes.
+ *
+ * @package FP\Privacy\Frontend
+ */
+
+namespace FP\Privacy\Frontend;
+
+use FP\Privacy\Utils\Options;
+use FP\Privacy\Utils\View;
+
+/**
+ * Registers frontend shortcodes.
+ */
+class Shortcodes {
+/**
+ * Options handler.
+ *
+ * @var Options
+ */
+private $options;
+
+/**
+ * View renderer.
+ *
+ * @var View
+ */
+private $view;
+
+/**
+ * Consent state.
+ *
+ * @var ConsentState
+ */
+private $state;
+
+/**
+ * Whether to force enqueue banner assets.
+ *
+ * @var bool
+ */
+private $force_enqueue = false;
+
+/**
+ * Constructor.
+ *
+ * @param Options      $options Options handler.
+ * @param View         $view    View renderer.
+ */
+public function __construct( Options $options, View $view ) {
+$this->options = $options;
+$this->view    = $view;
+}
+
+/**
+ * Inject consent state dependency.
+ *
+ * @param ConsentState $state State.
+ *
+ * @return void
+ */
+public function set_state( ConsentState $state ) {
+$this->state = $state;
+}
+
+/**
+ * Hooks.
+ *
+ * @return void
+ */
+public function hooks() {
+\add_action( 'init', array( $this, 'register_shortcodes' ) );
+\add_filter( 'fp_privacy_force_enqueue_banner', array( $this, 'maybe_force_enqueue' ) );
+}
+
+/**
+ * Register shortcodes.
+ *
+ * @return void
+ */
+public function register_shortcodes() {
+\add_shortcode( 'fp_privacy_policy', array( $this, 'render_privacy_policy' ) );
+\add_shortcode( 'fp_cookie_policy', array( $this, 'render_cookie_policy' ) );
+\add_shortcode( 'fp_cookie_preferences', array( $this, 'render_preferences_button' ) );
+\add_shortcode( 'fp_cookie_banner', array( $this, 'render_cookie_banner' ) );
+}
+
+/**
+ * Force enqueue when needed.
+ *
+ * @param bool $value Current value.
+ *
+ * @return bool
+ */
+public function maybe_force_enqueue( $value ) {
+return $value || $this->force_enqueue;
+}
+
+/**
+ * Render privacy policy template.
+ *
+ * @param array<string, string> $atts Attributes.
+ *
+ * @return string
+ */
+public function render_privacy_policy( $atts ) {
+$atts = \shortcode_atts(
+array(
+'lang' => \get_locale(),
+),
+$atts,
+'fp_privacy_policy'
+);
+
+$html = $this->view->render(
+'privacy-policy.php',
+array(
+'lang'     => $atts['lang'],
+'options'  => $this->options->all(),
+)
+);
+
+return \apply_filters( 'fp_privacy_policy_content', $html, $atts['lang'] );
+}
+
+/**
+ * Render cookie policy template.
+ *
+ * @param array<string, string> $atts Attributes.
+ *
+ * @return string
+ */
+public function render_cookie_policy( $atts ) {
+$atts = \shortcode_atts(
+array(
+'lang' => \get_locale(),
+),
+$atts,
+'fp_cookie_policy'
+);
+
+$html = $this->view->render(
+'cookie-policy.php',
+array(
+'lang'     => $atts['lang'],
+'options'  => $this->options->all(),
+)
+);
+
+return \apply_filters( 'fp_cookie_policy_content', $html, $atts['lang'] );
+}
+
+/**
+ * Render preferences button.
+ *
+ * @param array<string, string> $atts Attributes.
+ *
+ * @return string
+ */
+public function render_preferences_button( $atts ) {
+$atts = \shortcode_atts(
+array(
+'label'       => \__( 'Manage cookie preferences', 'fp-privacy' ),
+'lang'        => \get_locale(),
+'description' => \__( 'Opens the cookie preferences modal so you can review or update your consent settings.', 'fp-privacy' ),
+),
+$atts,
+'fp_cookie_preferences'
+);
+
+$label = \sanitize_text_field( $atts['label'] );
+if ( '' === $label ) {
+    $label = \__( 'Manage cookie preferences', 'fp-privacy' );
+}
+
+$lang = isset( $atts['lang'] ) ? $atts['lang'] : '';
+$lang = \preg_replace( '/[^A-Za-z0-9_\\-]/', '', $lang );
+if ( '' === $lang ) {
+    $lang = \get_locale();
+}
+
+$description = \sanitize_text_field( $atts['description'] );
+if ( '' === $description ) {
+    $description = \__( 'Opens the cookie preferences modal so you can review or update your consent settings.', 'fp-privacy' );
+}
+
+$state = $this->state ? $this->state->get_frontend_state( $lang ) : array( 'state' => array() );
+$last = isset( $state['state']['last_event'] ) ? $state['state']['last_event'] : '';
+
+if ( $last ) {
+    $description .= ' ' . \sprintf( \__( 'Last consent: %s', 'fp-privacy' ), $last );
+}
+
+$description = \trim( $description );
+$description_id = \wp_unique_id( 'fp-privacy-consent-hint-' );
+
+return \sprintf(
+'<button type=\"button\" class=\"fp-privacy-preferences\" data-fp-privacy-open aria-describedby=\"%2$s\">%1$s</button><span id=\"%2$s\" class=\"screen-reader-text\">%3$s</span>',
+\esc_html( $label ),
+\esc_attr( $description_id ),
+\esc_html( $description )
+);
+}
+
+/**
+ * Render banner container via shortcode.
+ *
+ * @param array<string, string> $atts Attributes.
+ *
+ * @return string
+ */
+public function render_cookie_banner( $atts ) {
+    $atts = \shortcode_atts(
+        array(
+            'lang'     => '',
+            'type'     => '',
+            'position' => '',
+            'force'    => '',
+        ),
+        $atts,
+        'fp_cookie_banner'
+    );
+
+    $lang = '' !== \trim( (string) $atts['lang'] ) ? \preg_replace( '/[^A-Za-z0-9_\\-]/', '', $atts['lang'] ) : '';
+
+    $type     = in_array( $atts['type'], array( 'floating', 'bar' ), true ) ? $atts['type'] : '';
+    $position = in_array( $atts['position'], array( 'top', 'bottom' ), true ) ? $atts['position'] : '';
+    $force    = in_array( strtolower( (string) $atts['force'] ), array( '1', 'true', 'yes' ), true );
+
+    $this->force_enqueue = true;
+
+    $attributes = array(
+        'class'                  => 'fp-privacy-banner-shortcode',
+        'data-fp-privacy-banner' => '1',
+    );
+
+    if ( '' !== $lang ) {
+        $attributes['data-lang'] = $lang;
+    }
+
+    if ( '' !== $type ) {
+        $attributes['data-layout-type'] = $type;
+    }
+
+    if ( '' !== $position ) {
+        $attributes['data-layout-position'] = $position;
+    }
+
+    if ( $force ) {
+        $attributes['data-force-display'] = '1';
+    }
+
+    $html = '<div';
+
+    foreach ( $attributes as $key => $value ) {
+        $html .= \sprintf( ' %s="%s"', $key, \esc_attr( $value ) );
+    }
+
+    $html .= '></div>';
+
+    return $html;
+}
+}

--- a/fp-privacy-cookie-policy/src/Integrations/ConsentMode.php
+++ b/fp-privacy-cookie-policy/src/Integrations/ConsentMode.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Google Consent Mode integration.
+ *
+ * @package FP\Privacy\Integrations
+ */
+
+namespace FP\Privacy\Integrations;
+
+use FP\Privacy\Utils\Options;
+
+/**
+ * Outputs consent mode defaults and helper script.
+ */
+class ConsentMode {
+/**
+ * Options handler.
+ *
+ * @var Options
+ */
+private $options;
+
+/**
+ * Constructor.
+ *
+ * @param Options $options Options.
+ */
+public function __construct( Options $options ) {
+$this->options = $options;
+}
+
+/**
+ * Hooks.
+ *
+ * @return void
+ */
+public function hooks() {
+\add_action( 'wp_enqueue_scripts', array( $this, 'ensure_script' ), 5 );
+\add_action( 'wp_footer', array( $this, 'print_defaults' ), 1 );
+}
+
+/**
+ * Register script if missing.
+ *
+ * @return void
+ */
+public function ensure_script() {
+if ( ! \wp_script_is( 'fp-privacy-consent-mode', 'registered' ) ) {
+\wp_register_script( 'fp-privacy-consent-mode', FP_PRIVACY_PLUGIN_URL . 'assets/js/consent-mode.js', array(), FP_PRIVACY_PLUGIN_VERSION, true );
+}
+}
+
+/**
+ * Print default consent mode configuration.
+ *
+ * @return void
+ */
+public function print_defaults() {
+if ( ! \wp_script_is( 'fp-privacy-consent-mode', 'enqueued' ) ) {
+return;
+}
+
+$defaults = $this->options->get( 'consent_mode_defaults' );
+$object   = \\wp_json_encode( $defaults );
+
+echo '<script type="text/javascript">window.fpPrivacyConsentDefaults = ' . $object . ';if(window.gtag){window.gtag("consent","default",' . $object . ');} </script>';
+}
+}

--- a/fp-privacy-cookie-policy/src/Integrations/DetectorRegistry.php
+++ b/fp-privacy-cookie-policy/src/Integrations/DetectorRegistry.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Service detector registry.
+ *
+ * @package FP\Privacy\Integrations
+ */
+
+namespace FP\Privacy\Integrations;
+
+/**
+ * Detects third-party services for policy generation.
+ */
+class DetectorRegistry {
+/**
+ * Get registry of services.
+ *
+ * @return array<string, array<string, mixed>>
+ */
+public function get_registry() {
+$services = array(
+'ga4'             => array(
+'name'        => 'Google Analytics 4',
+'category'    => 'statistics',
+'provider'    => 'Google LLC',
+'policy_url'  => 'https://policies.google.com/privacy',
+'cookies'     => array( '_ga', '_ga_*', '_gid' ),
+'legal_basis' => 'Consent',
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_ga4', 'Analytics measurement and reporting', \\get_locale() ),
+'retention'   => '26 months',
+'data_location' => 'United States',
+'detector'    => function () {
+return \\wp_script_is( 'google-analytics', 'enqueued' ) || \\get_option( 'ga_dash_tracking' ) || defined( 'GA_MEASUREMENT_ID' );
+},
+),
+'gtm'            => array(
+'name'        => 'Google Tag Manager',
+'category'    => 'marketing',
+'provider'    => 'Google LLC',
+'policy_url'  => 'https://policies.google.com/privacy',
+'cookies'     => array( '_gtm', '_dc_gtm_*' ),
+'legal_basis' => 'Consent',
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_gtm', 'Tag management and marketing integrations', \\get_locale() ),
+'retention'   => '14 months',
+'data_location' => 'United States',
+'detector'    => function () {
+return \\has_action( 'wp_head', 'gtm4wp_wp_head' ) || defined( 'GTM4WP_VERSION' );
+},
+),
+'facebook_pixel' => array(
+'name'        => 'Meta Pixel',
+'category'    => 'marketing',
+'provider'    => 'Meta Platforms, Inc.',
+'policy_url'  => 'https://www.facebook.com/policy.php',
+'cookies'     => array( '_fbp', 'fr' ),
+'legal_basis' => 'Consent',
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_facebook_pixel', 'Advertising conversion tracking', \\get_locale() ),
+'retention'   => '3 months',
+'data_location' => 'United States',
+'detector'    => function () {
+return defined( 'FACEBOOK_PIXEL_ID' ) || \\has_action( 'wp_head', 'facebook_pixel_head' );
+},
+),
+'hotjar'         => array(
+'name'        => 'Hotjar',
+'category'    => 'statistics',
+'provider'    => 'Hotjar Ltd.',
+'policy_url'  => 'https://www.hotjar.com/legal/policies/privacy/',
+'cookies'     => array( '_hjSession_*', '_hjFirstSeen' ),
+'legal_basis' => 'Consent',
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_hotjar', 'User behavior analytics and feedback', \\get_locale() ),
+'retention'   => '1 year',
+'data_location' => 'European Union',
+'detector'    => function () {
+return \\wp_script_is( 'hotjar-tracking', 'enqueued' ) || defined( 'HOTJAR_SITE_ID' );
+},
+),
+'clarity'        => array(
+'name'        => 'Microsoft Clarity',
+'category'    => 'statistics',
+'provider'    => 'Microsoft Corporation',
+'policy_url'  => 'https://privacy.microsoft.com/',
+'cookies'     => array( '_clck', '_clsk' ),
+'legal_basis' => 'Consent',
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_clarity', 'Session replays and heatmaps', \\get_locale() ),
+'retention'   => '1 year',
+'data_location' => 'United States',
+'detector'    => function () {
+return defined( 'CLARITY_PROJECT_ID' ) || \\has_action( 'wp_head', 'ms_clarity_tag' );
+},
+),
+recaptcha        => array(
+'name'        => 'Google reCAPTCHA',
+'category'    => 'necessary',
+'provider'    => 'Google LLC',
+'policy_url'  => 'https://policies.google.com/privacy',
+'cookies'     => array( '_GRECAPTCHA' ),
+'legal_basis' => 'Legitimate interest',
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_recaptcha', 'Protect forms from spam and abuse', \\get_locale() ),
+'retention'   => 'Persistent',
+'data_location' => 'United States',
+'detector'    => function () {
+return \\wp_script_is( 'google-recaptcha', 'enqueued' ) || defined( 'RECAPTCHA_SITE_KEY' );
+},
+),
+youtube          => array(
+'name'        => 'YouTube embeds',
+'category'    => 'marketing',
+'provider'    => 'Google LLC',
+'policy_url'  => 'https://policies.google.com/privacy',
+'cookies'     => array( 'VISITOR_INFO1_LIVE', 'YSC' ),
+'legal_basis' => 'Consent',
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_youtube', 'Embedded video playback', \\get_locale() ),
+'retention'   => '6 months',
+'data_location' => 'United States',
+'detector'    => function () {
+return \\has_shortcode( \\get_post_field( 'post_content', \\get_the_ID() ), 'youtube' ) || \\has_block( 'core-embed/youtube' );
+},
+),
+'vimeo'           => array(
+'name'        => 'Vimeo embeds',
+'category'    => 'marketing',
+'provider'    => 'Vimeo Inc.',
+'policy_url'  => 'https://vimeo.com/privacy',
+'cookies'     => array( 'vuid' ),
+'legal_basis' => 'Consent',
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_vimeo', 'Embedded video playback', \\get_locale() ),
+'retention'   => '2 years',
+'data_location' => 'United States',
+'detector'    => function () {
+return \\has_block( 'core-embed/vimeo' );
+},
+),
+'linkedin'        => array(
+'name'        => 'LinkedIn Insight Tag',
+'category'    => 'marketing',
+'provider'    => 'LinkedIn Corporation',
+'policy_url'  => 'https://www.linkedin.com/legal/privacy-policy',
+'cookies'     => array( 'bcookie', 'li_sugr' ),
+'legal_basis' => 'Consent',
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_linkedin', 'Advertising conversion tracking', \\get_locale() ),
+'retention'   => '6 months',
+'data_location' => 'United States',
+'detector'    => function () {
+return defined( 'LI_AJAX' ) || \\has_action( 'wp_head', 'linkedin_insight' );
+},
+),
+tiktok           => array(
+'name'        => 'TikTok Pixel',
+'category'    => 'marketing',
+'provider'    => 'TikTok Technology Limited',
+'policy_url'  => 'https://www.tiktok.com/legal/privacy-policy',
+'cookies'     => array( '_ttp' ),
+'legal_basis' => 'Consent',
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_tiktok', 'Advertising conversion tracking', \\get_locale() ),
+'retention'   => '13 months',
+'data_location' => 'United States',
+'detector'    => function () {
+return defined( 'TIKTOK_PIXEL_ID' );
+},
+),
+'matomo'         => array(
+'name'        => 'Matomo Analytics',
+'category'    => 'statistics',
+'provider'    => 'InnoCraft Ltd.',
+'policy_url'  => 'https://matomo.org/privacy-policy/',
+'cookies'     => array( '_pk_id*', '_pk_ses*' ),
+'legal_basis' => 'Consent',
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_matomo', 'Self-hosted analytics', \\get_locale() ),
+'retention'   => '13 months',
+'data_location' => 'European Union',
+'detector'    => function () {
+return defined( 'MATOMO_VERSION' ) || \\wp_script_is( 'matomo-tracking', 'enqueued' );
+},
+),
+'pinterest'      => array(
+'name'        => 'Pinterest Tag',
+'category'    => 'marketing',
+'provider'    => 'Pinterest Inc.',
+'policy_url'  => 'https://policy.pinterest.com/privacy-policy',
+'cookies'     => array( '_pinterest_ct_*' ),
+'legal_basis' => 'Consent',
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_pinterest', 'Advertising conversion tracking', \\get_locale() ),
+'retention'   => '13 months',
+'data_location' => 'United States',
+'detector'    => function () {
+return defined( 'PINTEREST_TAG_ID' );
+},
+),
+'hubspot'        => array(
+'name'        => 'HubSpot',
+'category'    => 'marketing',
+'provider'    => 'HubSpot, Inc.',
+'policy_url'  => 'https://legal.hubspot.com/privacy-policy',
+'cookies'     => array( '__hstc', '__hssrc', '__hssc' ),
+'legal_basis' => 'Consent',
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_hubspot', 'Marketing automation and CRM', \\get_locale() ),
+'retention'   => '13 months',
+'data_location' => 'United States',
+'detector'    => function () {
+return defined( 'HUBSPOT_API_KEY' ) || \\wp_script_is( 'leadin-script-loader', 'enqueued' );
+},
+),
+'woocommerce'    => array(
+'name'        => 'WooCommerce',
+'category'    => 'necessary',
+'provider'    => 'Automattic Inc.',
+'policy_url'  => 'https://automattic.com/privacy/',
+'cookies'     => array( 'woocommerce_cart_hash', 'woocommerce_items_in_cart', 'wp_woocommerce_session_*' ),
+'legal_basis' => 'Contract',
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_woocommerce', 'E-commerce cart functionality', \\get_locale() ),
+'retention'   => 'Session',
+'data_location' => 'European Union',
+'detector'    => function () {
+return class_exists( '\\WooCommerce' );
+},
+),
+);
+
+return \apply_filters( 'fp_privacy_services_registry', $services );
+}
+
+/**
+ * Detect services and mark results.
+ *
+ * @return array<int, array<string, mixed>>
+ */
+public function detect_services() {
+$registry = $this->get_registry();
+$results  = array();
+
+foreach ( $registry as $key => $service ) {
+$detected = false;
+if ( isset( $service['detector'] ) && \is_callable( $service['detector'] ) ) {
+$detected = (bool) \\call_user_func( $service['detector'] );
+}
+
+$service['key']      = $key;
+$service['detected'] = $detected;
+unset( $service['detector'] );
+$results[] = $service;
+}
+
+return $results;
+}
+}

--- a/fp-privacy-cookie-policy/src/REST/Controller.php
+++ b/fp-privacy-cookie-policy/src/REST/Controller.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * REST controller.
+ *
+ * @package FP\Privacy\REST
+ */
+
+namespace FP\Privacy\REST;
+
+use FP\Privacy\Consent\LogModel;
+use FP\Privacy\Frontend\ConsentState;
+use FP\Privacy\Utils\Options;
+use FP\Privacy\Admin\PolicyGenerator;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Registers REST API routes.
+ */
+class Controller {
+/**
+ * Consent state.
+ *
+ * @var ConsentState
+ */
+private $state;
+
+/**
+ * Options handler.
+ *
+ * @var Options
+ */
+private $options;
+
+/**
+ * Policy generator.
+ *
+ * @var PolicyGenerator
+ */
+private $generator;
+
+/**
+ * Log model.
+ *
+ * @var LogModel
+ */
+private $log_model;
+
+/**
+ * Constructor.
+ *
+ * @param ConsentState    $state     State handler.
+ * @param Options         $options   Options handler.
+ * @param PolicyGenerator $generator Generator.
+ * @param LogModel        $log_model Log model.
+ */
+public function __construct( ConsentState $state, Options $options, PolicyGenerator $generator, LogModel $log_model ) {
+$this->state     = $state;
+$this->options   = $options;
+$this->generator = $generator;
+$this->log_model = $log_model;
+}
+
+/**
+ * Hooks.
+ *
+ * @return void
+ */
+public function hooks() {
+\\add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+}
+
+/**
+ * Register routes.
+ *
+ * @return void
+ */
+public function register_routes() {
+\\register_rest_route(
+'fp-privacy/v1',
+'/consent/summary',
+array(
+'permission_callback' => function () {
+return \\current_user_can( 'manage_options' );
+},
+'methods'             => 'GET',
+'callback'            => array( $this, 'get_summary' ),
+)
+);
+
+\\register_rest_route(
+'fp-privacy/v1',
+'/consent',
+array(
+'permission_callback' => '__return_true',
+'methods'             => 'POST',
+'callback'            => array( $this, 'post_consent' ),
+)
+);
+
+\\register_rest_route(
+'fp-privacy/v1',
+'/revision/bump',
+array(
+'permission_callback' => function () {
+return \\current_user_can( 'manage_options' );
+},
+'methods'             => 'POST',
+'callback'            => array( $this, 'bump_revision' ),
+)
+);
+}
+
+/**
+ * Summary endpoint.
+ *
+ * @return WP_REST_Response
+ */
+public function get_summary() {
+$data = array(
+'summary'  => $this->log_model->summary_last_30_days(),
+'total'    => $this->log_model->count(),
+'options'  => $this->options->all(),
+'snapshot' => $this->generator->snapshot(),
+);
+
+return new WP_REST_Response( $data, 200 );
+}
+
+/**
+ * Save consent via REST.
+ *
+ * @param WP_REST_Request $request Request.
+ *
+ * @return WP_REST_Response|WP_Error
+ */
+public function post_consent( WP_REST_Request $request ) {
+$nonce = $request->get_header( 'X-WP-Nonce' );
+if ( ! $nonce || ! \\wp_verify_nonce( $nonce, 'wp_rest' ) ) {
+return new WP_Error( 'fp_privacy_invalid_nonce', \__( 'Invalid security token.', 'fp-privacy' ), array( 'status' => 403 ) );
+}
+
+$ip      = isset( $_SERVER['REMOTE_ADDR'] ) ? \\sanitize_text_field( \\wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : ''; // for rate limiting only.
+$limit   = 'fp_privacy_rate_' . hash( 'sha256', $ip . FP_PRIVACY_IP_SALT );
+$attempt = (int) \\get_transient( $limit );
+if ( $attempt > 10 ) {
+return new WP_Error( 'fp_privacy_rate_limited', \__( 'Too many requests. Please try again later.', 'fp-privacy' ), array( 'status' => 429 ) );
+}
+\\set_transient( $limit, $attempt + 1, MINUTE_IN_SECONDS * 10 );
+
+$event  = \\sanitize_text_field( $request->get_param( 'event' ) );
+$states = $request->get_param( 'states' );
+$lang   = \\sanitize_text_field( $request->get_param( 'lang' ) );
+
+if ( ! \is_array( $states ) ) {
+$states = array();
+}
+
+$result = $this->state->save_event( $event, $states, $lang );
+
+return new WP_REST_Response( $result, 200 );
+}
+
+/**
+ * Bump revision.
+ *
+ * @param WP_REST_Request $request Request.
+ *
+ * @return WP_REST_Response
+ */
+public function bump_revision( WP_REST_Request $request ) {
+$this->options->bump_revision();
+$this->options->set( $this->options->all() );
+
+return new WP_REST_Response( array( 'revision' => $this->options->get( 'consent_revision' ) ), 200 );
+}
+}

--- a/fp-privacy-cookie-policy/src/Utils/I18n.php
+++ b/fp-privacy-cookie-policy/src/Utils/I18n.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Internationalization helper.
+ *
+ * @package FP\Privacy\Utils
+ */
+
+namespace FP\Privacy\Utils;
+
+use function add_action;
+use function dirname;
+use function load_plugin_textdomain;
+use function plugin_basename;
+
+/**
+ * Handles text domain loading.
+ */
+class I18n {
+	/**
+	 * Register hooks.
+	 *
+	 * @return void
+	 */
+	public function hooks(): void {
+		add_action( 'plugins_loaded', array( $this, 'load_textdomain' ), 5 );
+	}
+
+	/**
+	 * Load the plugin text domain.
+	 *
+	 * @return void
+	 */
+	public function load_textdomain(): void {
+		load_plugin_textdomain(
+			'fp-privacy',
+			false,
+			dirname( plugin_basename( FP_PRIVACY_PLUGIN_FILE ) ) . '/languages'
+		);
+	}
+}

--- a/fp-privacy-cookie-policy/src/Utils/Validator.php
+++ b/fp-privacy-cookie-policy/src/Utils/Validator.php
@@ -1,0 +1,491 @@
+<?php
+/**
+ * Validation utilities.
+ *
+ * @package FP\Privacy\Utils
+ */
+
+namespace FP\Privacy\Utils;
+
+use const FILTER_VALIDATE_INT;
+use function absint;
+use function esc_url_raw;
+use function filter_var;
+use function is_array;
+use function preg_match;
+use function rest_sanitize_boolean;
+use function sanitize_email;
+use function sanitize_hex_color;
+use function sanitize_key;
+use function sanitize_text_field;
+use function wp_kses_post;
+use function wp_parse_args;
+
+/**
+ * Provides reusable validation helpers.
+ */
+class Validator {
+	/**
+	 * Normalize a boolean value.
+	 *
+	 * @param mixed $value Raw value.
+	 *
+	 * @return bool
+	 */
+	public static function bool( $value ): bool {
+		return (bool) rest_sanitize_boolean( $value );
+	}
+
+	/**
+	 * Normalize an integer within optional boundaries.
+	 *
+	 * @param mixed    $value   Raw value.
+	 * @param int      $default Default value.
+	 * @param int|null $min     Minimum value.
+	 * @param int|null $max     Maximum value.
+	 *
+	 * @return int
+	 */
+	public static function int( $value, int $default = 0, ?int $min = null, ?int $max = null ): int {
+		if ( null !== $value && '' !== $value ) {
+			$validated = filter_var( $value, FILTER_VALIDATE_INT );
+			if ( false !== $validated && null !== $validated ) {
+				$value = (int) $validated;
+			}
+		}
+
+		if ( ! is_int( $value ) ) {
+			$value = $default;
+		}
+
+		if ( null !== $min && $value < $min ) {
+			$value = $min;
+		}
+
+		if ( null !== $max && $value > $max ) {
+			$value = $max;
+		}
+
+		return (int) $value;
+	}
+
+	/**
+	 * Sanitize plain text.
+	 *
+	 * @param mixed $value Raw value.
+	 *
+	 * @return string
+	 */
+	public static function text( $value ): string {
+		return sanitize_text_field( (string) $value );
+	}
+
+	/**
+	 * Sanitize multi-line text allowing basic markup.
+	 *
+	 * @param mixed $value Raw value.
+	 *
+	 * @return string
+	 */
+	public static function textarea( $value ): string {
+		return wp_kses_post( (string) $value );
+	}
+
+	/**
+	 * Sanitize URL value.
+	 *
+	 * @param mixed $value Raw value.
+	 *
+	 * @return string
+	 */
+	public static function url( $value ): string {
+		return esc_url_raw( (string) $value );
+	}
+
+	/**
+	 * Sanitize email value.
+	 *
+	 * @param mixed $value Raw value.
+	 *
+	 * @return string
+	 */
+	public static function email( $value ): string {
+		return sanitize_email( (string) $value );
+	}
+
+	/**
+	 * Sanitize hexadecimal color.
+	 *
+	 * @param mixed  $value   Raw value.
+	 * @param string $default Default fallback.
+	 *
+	 * @return string
+	 */
+	public static function hex_color( $value, string $default = '' ): string {
+		$color = sanitize_hex_color( (string) $value );
+
+		return $color ? $color : $default;
+	}
+
+	/**
+	 * Sanitize locale string.
+	 *
+	 * @param mixed  $value   Raw value.
+	 * @param string $default Default fallback.
+	 *
+	 * @return string
+	 */
+	public static function locale( $value, string $default = 'en_US' ): string {
+		$value = sanitize_text_field( (string) $value );
+
+		if ( '' === $value ) {
+			return $default;
+		}
+
+		if ( ! preg_match( '/^[A-Za-z]{2,}([_-][A-Za-z0-9]{2,})?$/', $value ) ) {
+			return $default;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Sanitize a list of locale codes ensuring uniqueness.
+	 *
+	 * @param mixed  $values   Raw values.
+	 * @param string $fallback Fallback locale.
+	 *
+	 * @return array<int, string>
+	 */
+	public static function locale_list( $values, string $fallback ): array {
+		$values  = is_array( $values ) ? $values : array();
+		$locales = array();
+
+		foreach ( $values as $value ) {
+			$locale = self::locale( $value, '' );
+
+			if ( '' === $locale || in_array( $locale, $locales, true ) ) {
+				continue;
+			}
+
+			$locales[] = $locale;
+		}
+
+		if ( empty( $locales ) ) {
+			$locales[] = self::locale( $fallback, 'en_US' );
+		}
+
+		return $locales;
+	}
+
+	/**
+	 * Validate choice against allowed values.
+	 *
+	 * @param mixed             $value   Raw value.
+	 * @param array<int,string> $allowed Allowed values.
+	 * @param string            $default Default fallback.
+	 *
+	 * @return string
+	 */
+	public static function choice( $value, array $allowed, string $default ): string {
+		$value = sanitize_text_field( (string) $value );
+
+		return in_array( $value, $allowed, true ) ? $value : $default;
+	}
+
+	/**
+	 * Sanitize the color palette configuration.
+	 *
+	 * @param array<string, mixed>  $palette  Palette values.
+	 * @param array<string, string> $defaults Default palette.
+	 *
+	 * @return array<string, string>
+	 */
+	public static function sanitize_palette( array $palette, array $defaults ): array {
+		$palette   = wp_parse_args( $palette, $defaults );
+		$sanitized = array();
+
+		foreach ( $defaults as $key => $color ) {
+			$sanitized[ $key ] = self::hex_color( $palette[ $key ] ?? $color, $color );
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Sanitize banner texts per language.
+	 *
+	 * @param array<string, array<string, mixed>> $texts     Banner texts.
+	 * @param array<int, string>                  $languages Active languages.
+	 * @param array<string, string>               $defaults  Default text map.
+	 *
+	 * @return array<string, array<string, string>>
+	 */
+	public static function sanitize_banner_texts( array $texts, array $languages, array $defaults ): array {
+		$sanitized = array();
+
+		foreach ( $languages as $language ) {
+			$language = self::locale( $language, 'en_US' );
+			$source   = isset( $texts[ $language ] ) && is_array( $texts[ $language ] ) ? $texts[ $language ] : array();
+
+			$sanitized[ $language ] = array(
+				'title'       => self::text( $source['title'] ?? ( $defaults['title'] ?? '' ) ),
+				'message'     => self::textarea( $source['message'] ?? ( $defaults['message'] ?? '' ) ),
+				'btn_accept'  => self::text( $source['btn_accept'] ?? ( $defaults['btn_accept'] ?? '' ) ),
+				'btn_reject'  => self::text( $source['btn_reject'] ?? ( $defaults['btn_reject'] ?? '' ) ),
+				'btn_prefs'   => self::text( $source['btn_prefs'] ?? ( $defaults['btn_prefs'] ?? '' ) ),
+				'link_policy' => self::url( $source['link_policy'] ?? ( $defaults['link_policy'] ?? '' ) ),
+			);
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Sanitize consent mode defaults.
+	 *
+	 * @param array<string, string> $values   Raw values.
+	 * @param array<string, string> $defaults Default values.
+	 *
+	 * @return array<string, string>
+	 */
+	public static function sanitize_consent_mode( array $values, array $defaults ): array {
+		$allowed   = array( 'granted', 'denied' );
+		$sanitized = array();
+
+		foreach ( $defaults as $key => $default ) {
+			$raw = isset( $values[ $key ] ) ? strtolower( (string) $values[ $key ] ) : $default;
+
+			if ( ! in_array( $raw, $allowed, true ) ) {
+				$raw = $default;
+			}
+
+			$sanitized[ $key ] = $raw;
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Sanitize owner and DPO fields.
+	 *
+	 * @param array<string, mixed> $fields Raw fields.
+	 *
+	 * @return array<string, string>
+	 */
+	public static function sanitize_owner_fields( array $fields ): array {
+		$fields = wp_parse_args(
+			$fields,
+			array(
+				'org_name'      => '',
+				'vat'           => '',
+				'address'       => '',
+				'dpo_name'      => '',
+				'dpo_email'     => '',
+				'privacy_email' => '',
+			)
+		);
+
+		return array(
+			'org_name'      => self::text( $fields['org_name'] ),
+			'vat'           => self::text( $fields['vat'] ),
+			'address'       => self::textarea( $fields['address'] ),
+			'dpo_name'      => self::text( $fields['dpo_name'] ),
+			'dpo_email'     => self::email( $fields['dpo_email'] ),
+			'privacy_email' => self::email( $fields['privacy_email'] ),
+		);
+	}
+
+	/**
+	 * Sanitize pages mapping per language.
+	 *
+	 * @param array<string, mixed> $pages     Raw pages mapping.
+	 * @param array<int, string>   $languages Active languages.
+	 *
+	 * @return array<string, array<string, int>>
+	 */
+	public static function sanitize_pages( array $pages, array $languages ): array {
+		$defaults = array(
+			'privacy_policy_page_id' => array(),
+			'cookie_policy_page_id'  => array(),
+		);
+
+		$pages = wp_parse_args( $pages, $defaults );
+
+		foreach ( $defaults as $key => $_default ) {
+			$map = array();
+
+			if ( isset( $pages[ $key ] ) && is_array( $pages[ $key ] ) ) {
+				foreach ( $pages[ $key ] as $language => $page_id ) {
+					$lang_key         = self::locale( $language, $languages[0] ?? 'en_US' );
+					$map[ $lang_key ] = absint( $page_id );
+				}
+			}
+
+			foreach ( $languages as $language ) {
+				$language = self::locale( $language, 'en_US' );
+
+				if ( ! isset( $map[ $language ] ) ) {
+					$map[ $language ] = 0;
+				}
+			}
+
+			$pages[ $key ] = $map;
+		}
+
+		return $pages;
+	}
+
+	/**
+	 * Sanitize categories definition.
+	 *
+	 * @param array<string, mixed> $categories Raw categories.
+	 * @param array<int, string>   $languages  Active languages.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public static function sanitize_categories( array $categories, array $languages ): array {
+		$sanitized = array();
+
+		foreach ( $categories as $slug => $category ) {
+			$key = sanitize_key( $slug );
+
+			if ( '' === $key ) {
+				continue;
+			}
+
+			$category = is_array( $category ) ? $category : array();
+
+			$labels       = isset( $category['label'] ) && is_array( $category['label'] ) ? $category['label'] : array();
+			$descriptions = isset( $category['description'] ) && is_array( $category['description'] ) ? $category['description'] : array();
+			$services     = isset( $category['services'] ) && is_array( $category['services'] ) ? $category['services'] : array();
+
+			$sanitized[ $key ] = array(
+				'label'       => array(),
+				'description' => array(),
+				'locked'      => self::bool( $category['locked'] ?? false ),
+				'services'    => array(),
+			);
+
+			foreach ( $languages as $language ) {
+				$language = self::locale( $language, 'en_US' );
+				$label    = $labels[ $language ] ?? ( $labels['default'] ?? ( $labels ? reset( $labels ) : '' ) );
+				$desc     = $descriptions[ $language ] ?? ( $descriptions['default'] ?? ( $descriptions ? reset( $descriptions ) : '' ) );
+
+				$sanitized[ $key ]['label'][ $language ]       = self::text( $label );
+				$sanitized[ $key ]['description'][ $language ] = self::textarea( $desc );
+			}
+
+			$sanitized[ $key ]['services'] = self::sanitize_services( $services, $languages );
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Sanitize services definition grouped by language.
+	 *
+	 * @param array<string, mixed> $services Raw services per language.
+	 * @param array<int, string>   $languages Active languages.
+	 *
+	 * @return array<string, array<int, array<string, mixed>>>
+	 */
+	public static function sanitize_services( array $services, array $languages ): array {
+		$sanitized = array();
+
+		foreach ( $services as $language => $entries ) {
+			$lang = self::locale( $language, $languages[0] ?? 'en_US' );
+
+			if ( ! in_array( $lang, $languages, true ) ) {
+				continue;
+			}
+
+			if ( ! is_array( $entries ) ) {
+				continue;
+			}
+
+			foreach ( $entries as $entry ) {
+				if ( ! is_array( $entry ) ) {
+					continue;
+				}
+
+				$sanitized[ $lang ][] = self::sanitize_service_entry( $entry );
+			}
+		}
+
+		foreach ( $languages as $language ) {
+			$language = self::locale( $language, 'en_US' );
+
+			if ( ! isset( $sanitized[ $language ] ) ) {
+				$sanitized[ $language ] = array();
+			}
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Sanitize single service entry.
+	 *
+	 * @param array<string, mixed> $service Service definition.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function sanitize_service_entry( array $service ): array {
+		$cookies = array();
+
+		if ( isset( $service['cookies'] ) && is_array( $service['cookies'] ) ) {
+			foreach ( $service['cookies'] as $cookie ) {
+				if ( ! is_array( $cookie ) ) {
+					continue;
+				}
+
+				$cookies[] = self::sanitize_cookie_entry( $cookie );
+			}
+		}
+
+		$signals = array();
+
+		if ( isset( $service['uses_consent_mode'] ) && is_array( $service['uses_consent_mode'] ) ) {
+			$allowed = array( 'analytics_storage', 'ad_storage', 'ad_user_data', 'ad_personalization', 'functionality_storage', 'security_storage' );
+
+			foreach ( $service['uses_consent_mode'] as $signal ) {
+				$signal = sanitize_text_field( (string) $signal );
+
+				if ( in_array( $signal, $allowed, true ) && ! in_array( $signal, $signals, true ) ) {
+					$signals[] = $signal;
+				}
+			}
+		}
+
+		return array(
+			'key'               => sanitize_key( $service['key'] ?? '' ),
+			'name'              => self::text( $service['name'] ?? '' ),
+			'provider'          => self::text( $service['provider'] ?? '' ),
+			'purpose'           => self::textarea( $service['purpose'] ?? '' ),
+			'policy_url'        => self::url( $service['policy_url'] ?? '' ),
+			'retention'         => self::text( $service['retention'] ?? '' ),
+			'data_collected'    => self::textarea( $service['data_collected'] ?? '' ),
+			'legal_basis'       => self::text( $service['legal_basis'] ?? '' ),
+			'data_transfer'     => self::textarea( $service['data_transfer'] ?? '' ),
+			'cookies'           => $cookies,
+			'uses_consent_mode' => $signals,
+		);
+	}
+
+	/**
+	 * Sanitize individual cookie entry for a service.
+	 *
+	 * @param array<string, mixed> $cookie Cookie definition.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function sanitize_cookie_entry( array $cookie ): array {
+		return array(
+			'name'        => self::text( $cookie['name'] ?? '' ),
+			'domain'      => self::text( $cookie['domain'] ?? '' ),
+			'duration'    => self::text( $cookie['duration'] ?? '' ),
+			'description' => self::textarea( $cookie['description'] ?? '' ),
+		);
+	}
+}

--- a/fp-privacy-cookie-policy/src/Utils/View.php
+++ b/fp-privacy-cookie-policy/src/Utils/View.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * View renderer.
+ *
+ * @package FP\Privacy\Utils
+ */
+
+namespace FP\Privacy\Utils;
+
+use function apply_filters;
+use function ob_get_clean;
+use function ob_start;
+use function str_replace;
+use function trailingslashit;
+use function wp_normalize_path;
+
+/**
+ * Simple view rendering helper.
+ */
+class View {
+	/**
+	 * Render a PHP template and return the output.
+	 *
+	 * @param string               $template Template path relative to the plugin directory.
+	 * @param array<string, mixed> $context  Data available inside the template.
+	 *
+	 * @return string
+	 */
+	public function render( string $template, array $context = array() ): string {
+		$path = $this->resolve_template_path( $template );
+
+		if ( '' === $path || ! file_exists( $path ) ) {
+			return '';
+		}
+
+		$context = apply_filters( 'fp_privacy_view_context', $context, $template );
+
+		ob_start();
+		extract( $context, EXTR_SKIP );
+		require $path;
+
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Resolve template path ensuring it points inside the plugin directory.
+	 *
+	 * @param string $template Template identifier.
+	 *
+	 * @return string
+	 */
+	private function resolve_template_path( string $template ): string {
+		$template = trim( $template );
+
+		if ( '' === $template ) {
+			return '';
+		}
+
+		$template = wp_normalize_path( $template );
+		$template = str_replace( array( '../', '..\\' ), '', $template );
+
+		if ( 0 !== strpos( $template, 'templates/' ) ) {
+			$template = 'templates/' . ltrim( $template, '/' );
+		}
+
+		return trailingslashit( FP_PRIVACY_PLUGIN_PATH ) . $template;
+	}
+}

--- a/fp-privacy-cookie-policy/templates/cookie-policy.php
+++ b/fp-privacy-cookie-policy/templates/cookie-policy.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Cookie policy template.
+ *
+ * @package FP\Privacy
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+
+$retention = isset( $options['retention_days'] ) ? (int) $options['retention_days'] : 180;
+?>
+<section class="fp-cookie-policy">
+<h2><?php echo esc_html__( 'About cookies', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'Cookies are small text files stored on your device. They allow us to remember your preferences, ensure the website works properly and measure performance. Some cookies are strictly necessary while others require your consent.', 'fp-privacy' ); ?></p>
+
+<h2><?php echo esc_html__( 'How we use cookies', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'We group cookies into categories so you can tailor your experience. You can update your preferences at any time using the cookie preferences button.', 'fp-privacy' ); ?></p>
+
+<h2><?php echo esc_html__( 'Retention of consent', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html( sprintf( __( 'Your consent choices are stored for %d days unless you change them earlier.', 'fp-privacy' ), $retention ) ); ?></p>
+
+<?php foreach ( $groups as $category => $services ) : ?>
+<div class="fp-cookie-category">
+<h3><?php echo esc_html( ucfirst( str_replace( '_', ' ', $category ) ) ); ?></h3>
+<table>
+<thead>
+<tr>
+<th><?php echo esc_html__( 'Service', 'fp-privacy' ); ?></th>
+<th><?php echo esc_html__( 'Purpose', 'fp-privacy' ); ?></th>
+<th><?php echo esc_html__( 'Cookies', 'fp-privacy' ); ?></th>
+<th><?php echo esc_html__( 'Retention', 'fp-privacy' ); ?></th>
+</tr>
+</thead>
+<tbody>
+<?php foreach ( $services as $service ) : ?>
+<tr>
+<td><?php echo esc_html( $service['name'] ); ?></td>
+<td><?php echo esc_html( $service['purpose'] ); ?></td>
+<td><?php echo esc_html( implode( ', ', (array) $service['cookies'] ) ); ?></td>
+<td><?php echo esc_html( $service['retention'] ); ?></td>
+</tr>
+<?php endforeach; ?>
+</tbody>
+</table>
+</div>
+<?php endforeach; ?>
+
+<h2><?php echo esc_html__( 'Managing cookies', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'You can revisit your preferences using the cookie preferences button or adjust your browser settings to delete or block cookies. Blocking essential cookies may impact site functionality.', 'fp-privacy' ); ?></p>
+
+<h2><?php echo esc_html__( 'Last update', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html( sprintf( __( 'This policy was generated on %s.', 'fp-privacy' ), wp_date( get_option( 'date_format' ) ) ) ); ?></p>
+</section>

--- a/fp-privacy-cookie-policy/templates/preferences-button.php
+++ b/fp-privacy-cookie-policy/templates/preferences-button.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Preferences button template.
+ *
+ * @package FP\Privacy
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+?>
+<button type="button" class="fp-privacy-preferences" data-fp-privacy-open>
+<?php echo esc_html__( 'Manage cookie preferences', 'fp-privacy' ); ?>
+</button>

--- a/fp-privacy-cookie-policy/templates/privacy-policy.php
+++ b/fp-privacy-cookie-policy/templates/privacy-policy.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Privacy policy template.
+ *
+ * @package FP\Privacy
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+
+$org      = isset( $options['org_name'] ) ? $options['org_name'] : '';
+$address  = isset( $options['address'] ) ? $options['address'] : '';
+$dpo_name = isset( $options['dpo_name'] ) ? $options['dpo_name'] : '';
+$dpo_mail = isset( $options['dpo_email'] ) ? $options['dpo_email'] : '';
+$privacy_mail = isset( $options['privacy_email'] ) ? $options['privacy_email'] : '';
+$vat      = isset( $options['vat'] ) ? $options['vat'] : '';
+?>
+<section class="fp-privacy-policy">
+<h2><?php echo esc_html__( 'Data controller', 'fp-privacy' ); ?></h2>
+<p>
+<?php echo esc_html( $org ); ?>
+<?php if ( $vat ) : ?> — <?php echo esc_html( sprintf( __( 'VAT/Tax ID: %s', 'fp-privacy' ), $vat ) ); ?><?php endif; ?><br/>
+<?php echo esc_html( $address ); ?><br/>
+<?php if ( $privacy_mail ) : ?><?php echo esc_html( sprintf( __( 'Contact: %s', 'fp-privacy' ), $privacy_mail ) ); ?><?php endif; ?>
+</p>
+
+<h2><?php echo esc_html__( 'Purposes of processing', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'We process personal data to provide our services, ensure security, measure performance and deliver personalized experiences in accordance with the selected consent preferences.', 'fp-privacy' ); ?></p>
+
+<h2><?php echo esc_html__( 'Legal bases', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'Depending on the specific processing activity we rely on consent, contractual necessity or legitimate interest. Marketing and analytics tools are only activated after explicit consent.', 'fp-privacy' ); ?></p>
+
+<h2><?php echo esc_html__( 'Recipients and data transfers', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'Data may be shared with technology partners listed below. Transfers outside the EU/EEA are protected through adequacy decisions, Standard Contractual Clauses or equivalent safeguards.', 'fp-privacy' ); ?></p>
+
+<h2><?php echo esc_html__( 'Retention', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'Consent records are stored for the period required by law. Technical cookies follow the lifespan indicated in the cookie tables.', 'fp-privacy' ); ?></p>
+
+<h2><?php echo esc_html__( 'Data subject rights', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'You can request access, rectification, erasure, restriction, portability or object to processing by contacting us. You can withdraw consent at any time from the cookie preferences interface.', 'fp-privacy' ); ?></p>
+
+<?php if ( $dpo_name || $dpo_mail ) : ?>
+<h2><?php echo esc_html__( 'Data Protection Officer', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html( $dpo_name ); ?> — <?php echo esc_html( $dpo_mail ); ?></p>
+<?php endif; ?>
+
+<h2><?php echo esc_html__( 'Services and cookies', 'fp-privacy' ); ?></h2>
+<?php foreach ( $groups as $category => $services ) : ?>
+<div class="fp-privacy-category-block">
+<h3><?php echo esc_html( ucfirst( str_replace( '_', ' ', $category ) ) ); ?></h3>
+<table>
+<thead>
+<tr>
+<th><?php echo esc_html__( 'Service', 'fp-privacy' ); ?></th>
+<th><?php echo esc_html__( 'Provider', 'fp-privacy' ); ?></th>
+<th><?php echo esc_html__( 'Purpose', 'fp-privacy' ); ?></th>
+<th><?php echo esc_html__( 'Cookies & Retention', 'fp-privacy' ); ?></th>
+<th><?php echo esc_html__( 'Legal basis', 'fp-privacy' ); ?></th>
+</tr>
+</thead>
+<tbody>
+<?php foreach ( $services as $service ) : ?>
+<tr>
+<td><?php echo esc_html( $service['name'] ); ?><?php if ( ! empty( $service['policy_url'] ) ) : ?> — <a href="<?php echo esc_url( $service['policy_url'] ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html__( 'Privacy policy', 'fp-privacy' ); ?></a><?php endif; ?></td>
+<td><?php echo esc_html( $service['provider'] ); ?></td>
+<td><?php echo esc_html( $service['purpose'] ); ?></td>
+<td><?php echo esc_html( implode( ', ', (array) $service['cookies'] ) ); ?> — <?php echo esc_html( $service['retention'] ); ?></td>
+<td><?php echo esc_html( $service['legal_basis'] ); ?></td>
+</tr>
+<?php endforeach; ?>
+</tbody>
+</table>
+</div>
+<?php endforeach; ?>
+
+<h2><?php echo esc_html__( 'How to exercise your rights', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'Submit your request via email or the dedicated contact form. We will respond within one month and may request additional information to verify your identity.', 'fp-privacy' ); ?></p>
+
+<h2><?php echo esc_html__( 'Supervisory authority', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'If you believe your privacy rights have been violated you can lodge a complaint with the competent supervisory authority.', 'fp-privacy' ); ?></p>
+</section>


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to lint the plugin, build the distributable zip, and attach it to tagged releases
- include a reusable bin/package.sh helper that stages the plugin sources, strips unwanted files, lints PHP, and creates the zip archive
- add repository-level .gitattributes and .gitignore rules for cleaner archives and working tree hygiene
- fix the plugin bootstrap callbacks to invoke the namespaced Plugin singleton with fully qualified class names

## Testing
- php -l fp-privacy-cookie-policy/fp-privacy-cookie-policy.php

------
https://chatgpt.com/codex/tasks/task_e_68d9a6d61414832fb3bf0f9c2541d2b3