### PR TITLE
Improve packaging workflow auto-detection

### DIFF
--- a/.github/workflows/build-zip.yml
+++ b/.github/workflows/build-zip.yml
@@ -31,21 +31,33 @@ jobs:
           tools: none
           coverage: none
 
-      - name: Determina slug, file principale e versione
+      - name: Determina slug, file principale e versione (auto-detect)
         id: meta
         run: |
           set -euo pipefail
           PLUGIN_SLUG="fp-privacy-cookie-policy"
-          MAIN_FILE="fp-privacy-cookie-policy.php"
-          if [ ! -f "$MAIN_FILE" ]; then
-            echo "File principale non trovato: $MAIN_FILE" >&2
+
+          # Cerca il main file ovunque (matching header "Plugin Name: FP Privacy and Cookie Policy")
+          MAIN_FILE="$(grep -RIl --exclude-dir=.git --include="*.php" -e "^.*Plugin Name:[[:space:]]*FP Privacy and Cookie Policy" . | head -n1 || true)"
+          if [ -z "${MAIN_FILE}" ]; then
+            echo "Main file non trovato: cerca l'header 'Plugin Name: FP Privacy and Cookie Policy'." >&2
             exit 1
           fi
-          VERSION="$(grep -E '^[[:space:]]*\*?[[:space:]]*Version:[[:space:]]*' "$MAIN_FILE" | head -n1 | sed -E 's/.*Version:[[:space:]]*//')"
-          VERSION_TRIM="$(echo "$VERSION" | tr -d '\r' | xargs)"
-          echo "version=$VERSION_TRIM" >> "$GITHUB_OUTPUT"
-          echo "slug=$PLUGIN_SLUG" >> "$GITHUB_OUTPUT"
-          echo "main=$MAIN_FILE" >> "$GITHUB_OUTPUT"
+
+          # Cartella radice del plugin (dir del main file)
+          PLUGIN_DIR="$(dirname "${MAIN_FILE}")"
+
+          # Estrai Version: dall'header
+          VERSION="$(grep -E '^[[:space:]]*\*?[[:space:]]*Version:[[:space:]]*' "${MAIN_FILE}" | head -n1 | sed -E 's/.*Version:[[:space:]]*//; s/[[:space:]]+$//')"
+          if [ -z "${VERSION}" ]; then
+            echo "Version non trovata nell'header di ${MAIN_FILE}" >&2
+            exit 1
+          fi
+
+          echo "slug=${PLUGIN_SLUG}"        >> "$GITHUB_OUTPUT"
+          echo "main=${MAIN_FILE}"          >> "$GITHUB_OUTPUT"
+          echo "plugin_dir=${PLUGIN_DIR}"   >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}"         >> "$GITHUB_OUTPUT"
 
       - name: Verifica corrispondenza tag ⇔ Version (se evento tag)
         if: startsWith(github.ref, 'refs/tags/')
@@ -73,9 +85,10 @@ jobs:
         env:
           PLUGIN_VERSION: ${{ steps.meta.outputs.version }}
           PLUGIN_SLUG: ${{ steps.meta.outputs.slug }}
+          PLUGIN_DIR: ${{ steps.meta.outputs.plugin_dir }}
         run: |
           set -euo pipefail
-          bin/package.sh "$PLUGIN_SLUG" "$PLUGIN_VERSION"
+          bin/package.sh "$PLUGIN_SLUG" "$PLUGIN_VERSION" "$PLUGIN_DIR"
           echo "zip_path=./build/${PLUGIN_SLUG}-${PLUGIN_VERSION}.zip" >> "$GITHUB_OUTPUT"
           echo "zip_name=${PLUGIN_SLUG}-${PLUGIN_VERSION}.zip" >> "$GITHUB_OUTPUT"
 

--- a/bin/package.sh
+++ b/bin/package.sh
@@ -3,19 +3,19 @@ set -euo pipefail
 
 SLUG="${1:-fp-privacy-cookie-policy}"
 VERSION="${2:-0.1.0}"
+PLUGIN_DIR_INPUT="${3:-.}"
+
 ROOT_DIR="$(pwd)"
-SOURCE_DIR="${ROOT_DIR}/${SLUG}"
 BUILD_DIR="${ROOT_DIR}/build"
 STAGING_DIR="${BUILD_DIR}/${SLUG}"
-
-if [ ! -d "${SOURCE_DIR}" ]; then
-  echo "Directory del plugin non trovato: ${SOURCE_DIR}" >&2
-  exit 1
-fi
 
 rm -rf "${BUILD_DIR}"
 mkdir -p "${STAGING_DIR}"
 
+# Percorso assoluto della sorgente da impacchettare
+SRC_DIR="$(cd "${PLUGIN_DIR_INPUT}" && pwd)"
+
+# File/dir da includere (relativi a SRC_DIR)
 INCLUDE_PATHS=(
   "fp-privacy-cookie-policy.php"
   "src"
@@ -33,26 +33,24 @@ INCLUDE_PATHS=(
   "bin/qa-checklist.md"
 )
 
+# Copia filtrata
 for p in "${INCLUDE_PATHS[@]}"; do
-  if [ -e "${SOURCE_DIR}/${p}" ]; then
-    if [ -d "${SOURCE_DIR}/${p}" ]; then
-      rsync -a --exclude ".DS_Store" "${SOURCE_DIR}/${p}" "${STAGING_DIR}/"
-    else
-      mkdir -p "${STAGING_DIR}/$(dirname "${p}")"
-      rsync -a "${SOURCE_DIR}/${p}" "${STAGING_DIR}/${p}"
-    fi
+  if [ -e "${SRC_DIR}/${p}" ]; then
+    rsync -a --exclude ".DS_Store" "${SRC_DIR}/${p}" "${STAGING_DIR}/"
   fi
 done
 
+# Esclusioni dure (anti-binary/dev)
 find "${STAGING_DIR}" -type f \
   \( -name "*.map" -o -name "*.min.*" -o -name "*.zip" -o -name "*.png" -o -name "*.jpg" -o -name "*.jpeg" -o -name "*.gif" \
   -o -name "*.svg" -o -name "*.webp" -o -name "*.ico" -o -name "*.lock" -o -name "composer.lock" \) \
   -delete
-
 rm -rf "${STAGING_DIR}/node_modules" "${STAGING_DIR}/vendor" "${STAGING_DIR}/dist" "${STAGING_DIR}/build" 2>/dev/null || true
 
+# Lint PHP nel pacchetto finale
 find "${STAGING_DIR}" -type f -name "*.php" -print0 | xargs -0 -n1 php -l
 
+# ZIP con cartella radice = slug
 pushd "${BUILD_DIR}" >/dev/null
 ZIP_NAME="${SLUG}-${VERSION}.zip"
 zip -r "${ZIP_NAME}" "${SLUG}" \


### PR DESCRIPTION
## Summary
- auto-detect the plugin main file, directory, and version in the build workflow so releases work from any subfolder
- pass the detected directory to the packaging script and reuse it for the artifact metadata
- update the packaging script to accept the plugin directory argument and copy files from that location while preserving binary exclusions

## Testing
- bin/package.sh fp-privacy-cookie-policy 0.1.0 fp-privacy-cookie-policy *(fails: parse error in existing CLI/Commands.php)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe7c43a54832fb26d0138891fe94e