### PR TITLE
Fix PHP parse errors from doubled backslashes

### DIFF
--- a/fp-privacy-cookie-policy/src/Admin/Menu.php
+++ b/fp-privacy-cookie-policy/src/Admin/Menu.php
@@ -19,7 +19,7 @@ const MENU_SLUG = 'fp-privacy';
  * @return void
  */
 public function hooks() {
-\\add_action( 'admin_menu', array( $this, 'register_menu' ) );
+\add_action( 'admin_menu', array( $this, 'register_menu' ) );
 }
 
 /**
@@ -28,11 +28,11 @@ public function hooks() {
  * @return void
  */
 public function register_menu() {
-if ( ! \\current_user_can( 'manage_options' ) ) {
+if ( ! \current_user_can( 'manage_options' ) ) {
 return;
 }
 
-\\add_menu_page(
+\add_menu_page(
 \__( 'Privacy & Cookie', 'fp-privacy' ),
 \__( 'Privacy & Cookie', 'fp-privacy' ),
 'manage_options',
@@ -42,7 +42,7 @@ array( $this, 'render_settings_page' ),
 59
 );
 
-\\add_submenu_page(
+\add_submenu_page(
 self::MENU_SLUG,
 \__( 'Settings', 'fp-privacy' ),
 \__( 'Settings', 'fp-privacy' ),
@@ -51,7 +51,7 @@ self::MENU_SLUG,
 array( $this, 'render_settings_page' )
 );
 
-\\add_submenu_page(
+\add_submenu_page(
 self::MENU_SLUG,
 \__( 'Policy editor', 'fp-privacy' ),
 \__( 'Policy editor', 'fp-privacy' ),
@@ -60,7 +60,7 @@ self::MENU_SLUG,
 array( $this, 'render_policy_editor' )
 );
 
-\\add_submenu_page(
+\add_submenu_page(
 self::MENU_SLUG,
 \__( 'Consent log', 'fp-privacy' ),
 \__( 'Consent log', 'fp-privacy' ),
@@ -69,7 +69,7 @@ self::MENU_SLUG,
 array( $this, 'render_consent_log' )
 );
 
-\\add_submenu_page(
+\add_submenu_page(
 self::MENU_SLUG,
 \__( 'Tools', 'fp-privacy' ),
 \__( 'Tools', 'fp-privacy' ),
@@ -78,7 +78,7 @@ self::MENU_SLUG,
 array( $this, 'render_tools' )
 );
 
-\\add_submenu_page(
+\add_submenu_page(
 self::MENU_SLUG,
 \__( 'Quick guide', 'fp-privacy' ),
 \__( 'Quick guide', 'fp-privacy' ),
@@ -94,7 +94,7 @@ array( $this, 'render_guide' )
  * @return void
  */
 public function render_settings_page() {
-\\do_action( 'fp_privacy_admin_page_settings' );
+\do_action( 'fp_privacy_admin_page_settings' );
 }
 
 /**
@@ -103,7 +103,7 @@ public function render_settings_page() {
  * @return void
  */
 public function render_policy_editor() {
-\\do_action( 'fp_privacy_admin_page_policy_editor' );
+\do_action( 'fp_privacy_admin_page_policy_editor' );
 }
 
 /**
@@ -112,7 +112,7 @@ public function render_policy_editor() {
  * @return void
  */
 public function render_consent_log() {
-\\do_action( 'fp_privacy_admin_page_consent_log' );
+\do_action( 'fp_privacy_admin_page_consent_log' );
 }
 
 /**
@@ -121,7 +121,7 @@ public function render_consent_log() {
  * @return void
  */
 public function render_tools() {
-\\do_action( 'fp_privacy_admin_page_tools' );
+\do_action( 'fp_privacy_admin_page_tools' );
 }
 
 /**
@@ -130,6 +130,6 @@ public function render_tools() {
  * @return void
  */
 public function render_guide() {
-\\do_action( 'fp_privacy_admin_page_guide' );
+\do_action( 'fp_privacy_admin_page_guide' );
 }
 }

--- a/fp-privacy-cookie-policy/src/CLI/Commands.php
+++ b/fp-privacy-cookie-policy/src/CLI/Commands.php
@@ -82,7 +82,7 @@ WP_CLI::log( 'Total events: ' . $total );
 foreach ( $summary as $event => $count ) {
 WP_CLI::log( ucfirst( str_replace( '_', ' ', $event ) ) . ': ' . $count );
 }
-$next = \\wp_next_scheduled( 'fp_privacy_cleanup' );
+$next = \wp_next_scheduled( 'fp_privacy_cleanup' );
 WP_CLI::log( 'Next cleanup: ' . ( $next ? gmdate( 'c', $next ) : 'not scheduled' ) );
 }
 
@@ -102,8 +102,8 @@ WP_CLI::warning( 'Existing table dropped.' );
 }
 
 $this->log_model->maybe_create_table();
-if ( ! \\wp_next_scheduled( 'fp_privacy_cleanup' ) ) {
-\\wp_schedule_event( time() + DAY_IN_SECONDS, 'daily', 'fp_privacy_cleanup' );
+if ( ! \wp_next_scheduled( 'fp_privacy_cleanup' ) ) {
+\wp_schedule_event( time() + DAY_IN_SECONDS, 'daily', 'fp_privacy_cleanup' );
 }
 WP_CLI::success( 'Consent log table ready.' );
 }
@@ -173,7 +173,7 @@ WP_CLI::error( 'Missing --file parameter.' );
 }
 
 $file = $assoc_args['file'];
-$written = file_put_contents( $file, \\wp_json_encode( $this->options->all(), JSON_PRETTY_PRINT ) );
+$written = file_put_contents( $file, \wp_json_encode( $this->options->all(), JSON_PRETTY_PRINT ) );
 if ( ! $written ) {
 WP_CLI::error( 'Unable to write file.' );
 }
@@ -197,7 +197,7 @@ WP_CLI::error( 'Invalid JSON file.' );
 }
 
 $this->options->set( $data );
-\\do_action( 'fp_privacy_settings_imported', $this->options->all() );
+\do_action( 'fp_privacy_settings_imported', $this->options->all() );
 
 WP_CLI::success( 'Settings imported.' );
 }
@@ -224,7 +224,7 @@ WP_CLI::log( sprintf( '%s [%s] - %s', $service['name'], $service['category'], $s
  * : Increment consent revision after regeneration.
  */
 public function regenerate( $args, $assoc_args ) {
-$lang = isset( $assoc_args['lang'] ) ? $assoc_args['lang'] : \\get_locale();
+$lang = isset( $assoc_args['lang'] ) ? $assoc_args['lang'] : \get_locale();
 $privacy = $this->generator->generate_privacy_policy( $lang );
 $cookie  = $this->generator->generate_cookie_policy( $lang );
 

--- a/fp-privacy-cookie-policy/src/Consent/ExporterEraser.php
+++ b/fp-privacy-cookie-policy/src/Consent/ExporterEraser.php
@@ -94,7 +94,7 @@ global $wpdb;
 $page      = max( 1, (int) $page );
 $per_page  = 100;
 $offset    = ( $page - 1 ) * $per_page;
-$consent_id = \\sanitize_text_field( $email );
+$consent_id = \sanitize_text_field( $email );
 
 $results = $wpdb->get_results(
 $wpdb->prepare(
@@ -111,12 +111,12 @@ $data = array();
 foreach ( $results as $row ) {
 $data[] = array(
 'name'  => \__( 'Consent Log Entry', 'fp-privacy' ),
-'value' => \\wp_json_encode( array(
+'value' => \wp_json_encode( array(
 'event'   => $row['event'],
 'lang'    => $row['lang'],
 'rev'     => (int) $row['rev'],
 'time'    => $row['created_at'],
-'states'  => \\json_decode( $row['states'], true ),
+'states'  => \json_decode( $row['states'], true ),
 'user_agent' => $row['ua'],
 ) ),
 );
@@ -144,7 +144,7 @@ global $wpdb;
 $page       = max( 1, (int) $page );
 $per_page   = 100;
 $offset     = ( $page - 1 ) * $per_page;
-$consent_id = \\sanitize_text_field( $email );
+$consent_id = \sanitize_text_field( $email );
 
 $rows = $wpdb->get_results(
 $wpdb->prepare(
@@ -156,7 +156,7 @@ $offset
 ARRAY_A
 );
 
-$ids = \\wp_list_pluck( $rows, 'id' );
+$ids = \wp_list_pluck( $rows, 'id' );
 
 $removed = 0;
 if ( $ids ) {

--- a/fp-privacy-cookie-policy/src/Consent/LogModel.php
+++ b/fp-privacy-cookie-policy/src/Consent/LogModel.php
@@ -82,14 +82,14 @@ $defaults = array(
 'created_at' => \current_time( 'mysql', true ),
 );
 
-$data = \\wp_parse_args( $data, $defaults );
+$data = \wp_parse_args( $data, $defaults );
 $data = array(
-'consent_id' => \\sanitize_text_field( $data['consent_id'] ),
+'consent_id' => \sanitize_text_field( $data['consent_id'] ),
 'event'      => in_array( $data['event'], array( 'accept_all', 'reject_all', 'consent', 'reset', 'revision_bump' ), true ) ? $data['event'] : 'consent',
-'states'     => \\wp_json_encode( $this->ensure_states( $data['states'] ) ),
-'ip_hash'    => \\sanitize_text_field( $data['ip_hash'] ),
-'ua'         => \\sanitize_text_field( $data['ua'] ),
-'lang'       => \\sanitize_text_field( $data['lang'] ),
+'states'     => \wp_json_encode( $this->ensure_states( $data['states'] ) ),
+'ip_hash'    => \sanitize_text_field( $data['ip_hash'] ),
+'ua'         => \sanitize_text_field( $data['ua'] ),
+'lang'       => \sanitize_text_field( $data['lang'] ),
 'rev'        => (int) $data['rev'],
 'created_at' => $this->sanitize_datetime( $data['created_at'] ),
 );
@@ -116,7 +116,7 @@ $defaults = array(
 'to'         => '',
 );
 
-$args = \\wp_parse_args( $args, $defaults );
+$args = \wp_parse_args( $args, $defaults );
 
 $where  = 'WHERE 1=1';
 $params = array();
@@ -179,7 +179,7 @@ $defaults = array(
 'from'   => '',
 'to'     => '',
 );
-$args = \\wp_parse_args( $args, $defaults );
+$args = \wp_parse_args( $args, $defaults );
 
 $where  = 'WHERE 1=1';
 $params = array();
@@ -222,7 +222,7 @@ return (int) $wpdb->get_var( $sql );
 public function delete_older_than( $days ) {
 global $wpdb;
 
-$threshold = \\gmdate( 'Y-m-d H:i:s', time() - ( (int) $days * DAY_IN_SECONDS ) );
+$threshold = \gmdate( 'Y-m-d H:i:s', time() - ( (int) $days * DAY_IN_SECONDS ) );
 
 return (int) $wpdb->query( $wpdb->prepare( "DELETE FROM {$this->table} WHERE created_at < %s", $threshold ) );
 }
@@ -235,7 +235,7 @@ return (int) $wpdb->query( $wpdb->prepare( "DELETE FROM {$this->table} WHERE cre
 public function summary_last_30_days() {
 global $wpdb;
 
-$from = \\gmdate( 'Y-m-d H:i:s', time() - ( 30 * DAY_IN_SECONDS ) );
+$from = \gmdate( 'Y-m-d H:i:s', time() - ( 30 * DAY_IN_SECONDS ) );
 
 $rows = $wpdb->get_results(
 $wpdb->prepare( "SELECT event, COUNT(*) as total FROM {$this->table} WHERE created_at >= %s GROUP BY event", $from ),
@@ -300,7 +300,7 @@ try {
 $dt = new DateTimeImmutable( $date, new DateTimeZone( 'UTC' ) );
 return $dt->format( 'Y-m-d H:i:s' );
 } catch ( Exception $e ) {
-return \\gmdate( 'Y-m-d H:i:s' );
+return \gmdate( 'Y-m-d H:i:s' );
 }
 }
 }

--- a/fp-privacy-cookie-policy/src/Frontend/Banner.php
+++ b/fp-privacy-cookie-policy/src/Frontend/Banner.php
@@ -54,41 +54,41 @@ public function hooks() {
  * @return void
  */
 public function enqueue_assets() {
-$lang      = \\determine_locale();
+$lang      = \determine_locale();
 $state     = $this->state->get_frontend_state( $lang );
 $should    = $state['state']['should_display'];
 $preview   = $state['state']['preview_mode'];
-$shortcode = \\apply_filters( 'fp_privacy_force_enqueue_banner', false );
+$shortcode = \apply_filters( 'fp_privacy_force_enqueue_banner', false );
 
 if ( ! $should && ! $preview && ! $shortcode ) {
 return;
 }
 
 $handle = 'fp-privacy-banner';
-\\wp_register_style( $handle, FP_PRIVACY_PLUGIN_URL . 'assets/css/banner.css', array(), FP_PRIVACY_PLUGIN_VERSION );
-\\wp_register_script( $handle, FP_PRIVACY_PLUGIN_URL . 'assets/js/banner.js', array(), FP_PRIVACY_PLUGIN_VERSION, true );
-\\wp_register_script( 'fp-privacy-consent-mode', FP_PRIVACY_PLUGIN_URL . 'assets/js/consent-mode.js', array(), FP_PRIVACY_PLUGIN_VERSION, true );
+\wp_register_style( $handle, FP_PRIVACY_PLUGIN_URL . 'assets/css/banner.css', array(), FP_PRIVACY_PLUGIN_VERSION );
+\wp_register_script( $handle, FP_PRIVACY_PLUGIN_URL . 'assets/js/banner.js', array(), FP_PRIVACY_PLUGIN_VERSION, true );
+\wp_register_script( 'fp-privacy-consent-mode', FP_PRIVACY_PLUGIN_URL . 'assets/js/consent-mode.js', array(), FP_PRIVACY_PLUGIN_VERSION, true );
 
-\\wp_enqueue_style( $handle );
-\\wp_add_inline_style( $handle, $this->build_palette_css( $state['layout']['palette'] ) );
+\wp_enqueue_style( $handle );
+\wp_add_inline_style( $handle, $this->build_palette_css( $state['layout']['palette'] ) );
 
-\\wp_enqueue_script( 'fp-privacy-consent-mode' );
-\\wp_enqueue_script( $handle );
+\wp_enqueue_script( 'fp-privacy-consent-mode' );
+\wp_enqueue_script( $handle );
 
-\\wp_localize_script(
+\wp_localize_script(
 $handle,
 'FP_PRIVACY_DATA',
 array(
-'ajaxUrl'   => \\admin_url( 'admin-ajax.php' ),
-'nonce'     => \\wp_create_nonce( 'fp-privacy-consent' ),
+'ajaxUrl'   => \admin_url( 'admin-ajax.php' ),
+'nonce'     => \wp_create_nonce( 'fp-privacy-consent' ),
 'options'   => $state,
 'cookie'    => array(
 'name'     => ConsentState::COOKIE_NAME,
-'duration' => (int) \\apply_filters( 'fp_privacy_cookie_duration_days', 180 ),
+'duration' => (int) \apply_filters( 'fp_privacy_cookie_duration_days', 180 ),
 ),
 'rest'      => array(
-'url'   => \\esc_url_raw( \\rest_url( 'fp-privacy/v1/consent' ) ),
-'nonce' => \\wp_create_nonce( 'wp_rest' ),
+'url'   => \esc_url_raw( \rest_url( 'fp-privacy/v1/consent' ) ),
+'nonce' => \wp_create_nonce( 'wp_rest' ),
 ),
 )
 );
@@ -113,7 +113,7 @@ echo '<div id="fp-privacy-banner-root" aria-live="polite"></div>';
 private function build_palette_css( $palette ) {
 $css = ':root {';
 foreach ( $palette as $key => $value ) {
-$css .= '--fp-privacy-' . \\sanitize_key( $key ) . ':' . \sanitize_hex_color( $value ) . ';';
+$css .= '--fp-privacy-' . \sanitize_key( $key ) . ':' . \sanitize_hex_color( $value ) . ';';
 }
 $css .= '}';
 

--- a/fp-privacy-cookie-policy/src/Integrations/ConsentMode.php
+++ b/fp-privacy-cookie-policy/src/Integrations/ConsentMode.php
@@ -61,7 +61,7 @@ return;
 }
 
 $defaults = $this->options->get( 'consent_mode_defaults' );
-$object   = \\wp_json_encode( $defaults );
+    $object   = \wp_json_encode( $defaults );
 
 $script = sprintf(
     '(function(){var defaults=%1$s;window.fpPrivacyConsentDefaults=defaults;window.dataLayer=window.dataLayer||[];if(typeof window.gtag==="function"){window.gtag("consent","default",defaults);}else{window.dataLayer.push(["consent","default",defaults]);}window.dataLayer.push({event:"gtm.init_consent",consentDefaults:defaults});})();',

--- a/fp-privacy-cookie-policy/src/Integrations/DetectorRegistry.php
+++ b/fp-privacy-cookie-policy/src/Integrations/DetectorRegistry.php
@@ -25,11 +25,11 @@ $services = array(
 'policy_url'  => 'https://policies.google.com/privacy',
 'cookies'     => array( '_ga', '_ga_*', '_gid' ),
 'legal_basis' => 'Consent',
-'purpose'     => \apply_filters( 'fp_privacy_service_purpose_ga4', 'Analytics measurement and reporting', \\get_locale() ),
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_ga4', 'Analytics measurement and reporting', \get_locale() ),
 'retention'   => '26 months',
 'data_location' => 'United States',
 'detector'    => function () {
-return \\wp_script_is( 'google-analytics', 'enqueued' ) || \\get_option( 'ga_dash_tracking' ) || defined( 'GA_MEASUREMENT_ID' );
+return \wp_script_is( 'google-analytics', 'enqueued' ) || \get_option( 'ga_dash_tracking' ) || defined( 'GA_MEASUREMENT_ID' );
 },
 ),
 'gtm'            => array(
@@ -39,11 +39,11 @@ return \\wp_script_is( 'google-analytics', 'enqueued' ) || \\get_option( 'ga_das
 'policy_url'  => 'https://policies.google.com/privacy',
 'cookies'     => array( '_gtm', '_dc_gtm_*' ),
 'legal_basis' => 'Consent',
-'purpose'     => \apply_filters( 'fp_privacy_service_purpose_gtm', 'Tag management and marketing integrations', \\get_locale() ),
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_gtm', 'Tag management and marketing integrations', \get_locale() ),
 'retention'   => '14 months',
 'data_location' => 'United States',
 'detector'    => function () {
-return \\has_action( 'wp_head', 'gtm4wp_wp_head' ) || defined( 'GTM4WP_VERSION' );
+return \has_action( 'wp_head', 'gtm4wp_wp_head' ) || defined( 'GTM4WP_VERSION' );
 },
 ),
 'facebook_pixel' => array(
@@ -53,11 +53,11 @@ return \\has_action( 'wp_head', 'gtm4wp_wp_head' ) || defined( 'GTM4WP_VERSION' 
 'policy_url'  => 'https://www.facebook.com/policy.php',
 'cookies'     => array( '_fbp', 'fr' ),
 'legal_basis' => 'Consent',
-'purpose'     => \apply_filters( 'fp_privacy_service_purpose_facebook_pixel', 'Advertising conversion tracking', \\get_locale() ),
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_facebook_pixel', 'Advertising conversion tracking', \get_locale() ),
 'retention'   => '3 months',
 'data_location' => 'United States',
 'detector'    => function () {
-return defined( 'FACEBOOK_PIXEL_ID' ) || \\has_action( 'wp_head', 'facebook_pixel_head' );
+return defined( 'FACEBOOK_PIXEL_ID' ) || \has_action( 'wp_head', 'facebook_pixel_head' );
 },
 ),
 'hotjar'         => array(
@@ -67,11 +67,11 @@ return defined( 'FACEBOOK_PIXEL_ID' ) || \\has_action( 'wp_head', 'facebook_pixe
 'policy_url'  => 'https://www.hotjar.com/legal/policies/privacy/',
 'cookies'     => array( '_hjSession_*', '_hjFirstSeen' ),
 'legal_basis' => 'Consent',
-'purpose'     => \apply_filters( 'fp_privacy_service_purpose_hotjar', 'User behavior analytics and feedback', \\get_locale() ),
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_hotjar', 'User behavior analytics and feedback', \get_locale() ),
 'retention'   => '1 year',
 'data_location' => 'European Union',
 'detector'    => function () {
-return \\wp_script_is( 'hotjar-tracking', 'enqueued' ) || defined( 'HOTJAR_SITE_ID' );
+return \wp_script_is( 'hotjar-tracking', 'enqueued' ) || defined( 'HOTJAR_SITE_ID' );
 },
 ),
 'clarity'        => array(
@@ -81,11 +81,11 @@ return \\wp_script_is( 'hotjar-tracking', 'enqueued' ) || defined( 'HOTJAR_SITE_
 'policy_url'  => 'https://privacy.microsoft.com/',
 'cookies'     => array( '_clck', '_clsk' ),
 'legal_basis' => 'Consent',
-'purpose'     => \apply_filters( 'fp_privacy_service_purpose_clarity', 'Session replays and heatmaps', \\get_locale() ),
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_clarity', 'Session replays and heatmaps', \get_locale() ),
 'retention'   => '1 year',
 'data_location' => 'United States',
 'detector'    => function () {
-return defined( 'CLARITY_PROJECT_ID' ) || \\has_action( 'wp_head', 'ms_clarity_tag' );
+return defined( 'CLARITY_PROJECT_ID' ) || \has_action( 'wp_head', 'ms_clarity_tag' );
 },
 ),
 recaptcha        => array(
@@ -95,11 +95,11 @@ recaptcha        => array(
 'policy_url'  => 'https://policies.google.com/privacy',
 'cookies'     => array( '_GRECAPTCHA' ),
 'legal_basis' => 'Legitimate interest',
-'purpose'     => \apply_filters( 'fp_privacy_service_purpose_recaptcha', 'Protect forms from spam and abuse', \\get_locale() ),
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_recaptcha', 'Protect forms from spam and abuse', \get_locale() ),
 'retention'   => 'Persistent',
 'data_location' => 'United States',
 'detector'    => function () {
-return \\wp_script_is( 'google-recaptcha', 'enqueued' ) || defined( 'RECAPTCHA_SITE_KEY' );
+return \wp_script_is( 'google-recaptcha', 'enqueued' ) || defined( 'RECAPTCHA_SITE_KEY' );
 },
 ),
 youtube          => array(
@@ -109,11 +109,11 @@ youtube          => array(
 'policy_url'  => 'https://policies.google.com/privacy',
 'cookies'     => array( 'VISITOR_INFO1_LIVE', 'YSC' ),
 'legal_basis' => 'Consent',
-'purpose'     => \apply_filters( 'fp_privacy_service_purpose_youtube', 'Embedded video playback', \\get_locale() ),
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_youtube', 'Embedded video playback', \get_locale() ),
 'retention'   => '6 months',
 'data_location' => 'United States',
 'detector'    => function () {
-return \\has_shortcode( \\get_post_field( 'post_content', \\get_the_ID() ), 'youtube' ) || \\has_block( 'core-embed/youtube' );
+return \has_shortcode( \get_post_field( 'post_content', \get_the_ID() ), 'youtube' ) || \has_block( 'core-embed/youtube' );
 },
 ),
 'vimeo'           => array(
@@ -123,11 +123,11 @@ return \\has_shortcode( \\get_post_field( 'post_content', \\get_the_ID() ), 'you
 'policy_url'  => 'https://vimeo.com/privacy',
 'cookies'     => array( 'vuid' ),
 'legal_basis' => 'Consent',
-'purpose'     => \apply_filters( 'fp_privacy_service_purpose_vimeo', 'Embedded video playback', \\get_locale() ),
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_vimeo', 'Embedded video playback', \get_locale() ),
 'retention'   => '2 years',
 'data_location' => 'United States',
 'detector'    => function () {
-return \\has_block( 'core-embed/vimeo' );
+return \has_block( 'core-embed/vimeo' );
 },
 ),
 'linkedin'        => array(
@@ -137,11 +137,11 @@ return \\has_block( 'core-embed/vimeo' );
 'policy_url'  => 'https://www.linkedin.com/legal/privacy-policy',
 'cookies'     => array( 'bcookie', 'li_sugr' ),
 'legal_basis' => 'Consent',
-'purpose'     => \apply_filters( 'fp_privacy_service_purpose_linkedin', 'Advertising conversion tracking', \\get_locale() ),
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_linkedin', 'Advertising conversion tracking', \get_locale() ),
 'retention'   => '6 months',
 'data_location' => 'United States',
 'detector'    => function () {
-return defined( 'LI_AJAX' ) || \\has_action( 'wp_head', 'linkedin_insight' );
+return defined( 'LI_AJAX' ) || \has_action( 'wp_head', 'linkedin_insight' );
 },
 ),
 tiktok           => array(
@@ -151,7 +151,7 @@ tiktok           => array(
 'policy_url'  => 'https://www.tiktok.com/legal/privacy-policy',
 'cookies'     => array( '_ttp' ),
 'legal_basis' => 'Consent',
-'purpose'     => \apply_filters( 'fp_privacy_service_purpose_tiktok', 'Advertising conversion tracking', \\get_locale() ),
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_tiktok', 'Advertising conversion tracking', \get_locale() ),
 'retention'   => '13 months',
 'data_location' => 'United States',
 'detector'    => function () {
@@ -165,11 +165,11 @@ return defined( 'TIKTOK_PIXEL_ID' );
 'policy_url'  => 'https://matomo.org/privacy-policy/',
 'cookies'     => array( '_pk_id*', '_pk_ses*' ),
 'legal_basis' => 'Consent',
-'purpose'     => \apply_filters( 'fp_privacy_service_purpose_matomo', 'Self-hosted analytics', \\get_locale() ),
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_matomo', 'Self-hosted analytics', \get_locale() ),
 'retention'   => '13 months',
 'data_location' => 'European Union',
 'detector'    => function () {
-return defined( 'MATOMO_VERSION' ) || \\wp_script_is( 'matomo-tracking', 'enqueued' );
+return defined( 'MATOMO_VERSION' ) || \wp_script_is( 'matomo-tracking', 'enqueued' );
 },
 ),
 'pinterest'      => array(
@@ -179,7 +179,7 @@ return defined( 'MATOMO_VERSION' ) || \\wp_script_is( 'matomo-tracking', 'enqueu
 'policy_url'  => 'https://policy.pinterest.com/privacy-policy',
 'cookies'     => array( '_pinterest_ct_*' ),
 'legal_basis' => 'Consent',
-'purpose'     => \apply_filters( 'fp_privacy_service_purpose_pinterest', 'Advertising conversion tracking', \\get_locale() ),
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_pinterest', 'Advertising conversion tracking', \get_locale() ),
 'retention'   => '13 months',
 'data_location' => 'United States',
 'detector'    => function () {
@@ -193,11 +193,11 @@ return defined( 'PINTEREST_TAG_ID' );
 'policy_url'  => 'https://legal.hubspot.com/privacy-policy',
 'cookies'     => array( '__hstc', '__hssrc', '__hssc' ),
 'legal_basis' => 'Consent',
-'purpose'     => \apply_filters( 'fp_privacy_service_purpose_hubspot', 'Marketing automation and CRM', \\get_locale() ),
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_hubspot', 'Marketing automation and CRM', \get_locale() ),
 'retention'   => '13 months',
 'data_location' => 'United States',
 'detector'    => function () {
-return defined( 'HUBSPOT_API_KEY' ) || \\wp_script_is( 'leadin-script-loader', 'enqueued' );
+return defined( 'HUBSPOT_API_KEY' ) || \wp_script_is( 'leadin-script-loader', 'enqueued' );
 },
 ),
 'woocommerce'    => array(
@@ -207,11 +207,11 @@ return defined( 'HUBSPOT_API_KEY' ) || \\wp_script_is( 'leadin-script-loader', '
 'policy_url'  => 'https://automattic.com/privacy/',
 'cookies'     => array( 'woocommerce_cart_hash', 'woocommerce_items_in_cart', 'wp_woocommerce_session_*' ),
 'legal_basis' => 'Contract',
-'purpose'     => \apply_filters( 'fp_privacy_service_purpose_woocommerce', 'E-commerce cart functionality', \\get_locale() ),
+'purpose'     => \apply_filters( 'fp_privacy_service_purpose_woocommerce', 'E-commerce cart functionality', \get_locale() ),
 'retention'   => 'Session',
 'data_location' => 'European Union',
 'detector'    => function () {
-return class_exists( '\\WooCommerce' );
+return class_exists( '\WooCommerce' );
 },
 ),
 );
@@ -231,7 +231,7 @@ $results  = array();
 foreach ( $registry as $key => $service ) {
 $detected = false;
 if ( isset( $service['detector'] ) && \is_callable( $service['detector'] ) ) {
-$detected = (bool) \\call_user_func( $service['detector'] );
+$detected = (bool) \call_user_func( $service['detector'] );
 }
 
 $service['key']      = $key;

--- a/fp-privacy-cookie-policy/src/REST/Controller.php
+++ b/fp-privacy-cookie-policy/src/REST/Controller.php
@@ -68,7 +68,7 @@ $this->log_model = $log_model;
  * @return void
  */
 public function hooks() {
-\\add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+    \add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 }
 
 /**
@@ -77,19 +77,19 @@ public function hooks() {
  * @return void
  */
 public function register_routes() {
-\\register_rest_route(
+        \register_rest_route(
 'fp-privacy/v1',
 '/consent/summary',
 array(
 'permission_callback' => function () {
-return \\current_user_can( 'manage_options' );
+            return \current_user_can( 'manage_options' );
 },
 'methods'             => 'GET',
 'callback'            => array( $this, 'get_summary' ),
 )
 );
 
-\\register_rest_route(
+        \register_rest_route(
 'fp-privacy/v1',
 '/consent',
 array(
@@ -99,12 +99,12 @@ array(
 )
 );
 
-\\register_rest_route(
+        \register_rest_route(
 'fp-privacy/v1',
 '/revision/bump',
 array(
 'permission_callback' => function () {
-return \\current_user_can( 'manage_options' );
+            return \current_user_can( 'manage_options' );
 },
 'methods'             => 'POST',
 'callback'            => array( $this, 'bump_revision' ),
@@ -137,23 +137,23 @@ return new WP_REST_Response( $data, 200 );
  */
 public function post_consent( WP_REST_Request $request ) {
 $nonce = $request->get_header( 'X-WP-Nonce' );
-if ( ! $nonce || ! \\wp_verify_nonce( $nonce, 'wp_rest' ) ) {
-return new WP_Error( 'fp_privacy_invalid_nonce', \__( 'Invalid security token.', 'fp-privacy' ), array( 'status' => 403 ) );
+if ( ! $nonce || ! \wp_verify_nonce( $nonce, 'wp_rest' ) ) {
+        return new WP_Error( 'fp_privacy_invalid_nonce', \__( 'Invalid security token.', 'fp-privacy' ), array( 'status' => 403 ) );
 }
 
-$ip      = isset( $_SERVER['REMOTE_ADDR'] ) ? \\sanitize_text_field( \\wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : ''; // for rate limiting only.
+$ip      = isset( $_SERVER['REMOTE_ADDR'] ) ? \sanitize_text_field( \wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : ''; // for rate limiting only.
 $limit   = 'fp_privacy_rate_' . hash( 'sha256', $ip . FP_PRIVACY_IP_SALT );
-$attempt = (int) \\get_transient( $limit );
+$attempt = (int) \get_transient( $limit );
 if ( $attempt > 10 ) {
 return new WP_Error( 'fp_privacy_rate_limited', \__( 'Too many requests. Please try again later.', 'fp-privacy' ), array( 'status' => 429 ) );
 }
-\\set_transient( $limit, $attempt + 1, MINUTE_IN_SECONDS * 10 );
+\set_transient( $limit, $attempt + 1, MINUTE_IN_SECONDS * 10 );
 
-$event  = \\sanitize_text_field( $request->get_param( 'event' ) );
+$event  = \sanitize_text_field( $request->get_param( 'event' ) );
 $states = $request->get_param( 'states' );
-$lang   = \\sanitize_text_field( $request->get_param( 'lang' ) );
+$lang   = \sanitize_text_field( $request->get_param( 'lang' ) );
 $consent_id = $request->get_param( 'consent_id' );
-$consent_id = $consent_id ? \\sanitize_text_field( $consent_id ) : '';
+$consent_id = $consent_id ? \sanitize_text_field( $consent_id ) : '';
 
 if ( ! \is_array( $states ) ) {
 $states = array();


### PR DESCRIPTION
## Summary
- replace doubled leading backslashes in Frontend\Banner with single root namespace calls so WordPress functions can execute
- apply the same namespace fix throughout admin, consent, integrations, REST, and CLI classes to resolve cascading parse errors
- ensure helper utilities encode and sanitize data using valid global function references

## Testing
- find fp-privacy-cookie-policy -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68dbecfeaa40832f9c167f45c3f1b1b3