### PR TITLE
Ensure consent modal stays above banner overlay

### DIFF
--- a/fp-privacy-cookie-policy/assets/css/banner.css
+++ b/fp-privacy-cookie-policy/assets/css/banner.css
@@ -92,7 +92,7 @@ left: 0;
 width: 100%;
 height: 100%;
 background: rgba(17, 24, 39, 0.65);
-z-index: 99998;
+z-index: 2147483646;
 display: none;
 align-items: center;
 justify-content: center;
@@ -108,6 +108,7 @@ border-radius: 12px;
 padding: 2rem;
 box-shadow: 0 20px 40px rgba(15, 23, 42, 0.3);
 position: relative;
+z-index: 2147483647;
 }
 
 .fp-privacy-modal h2 {


### PR DESCRIPTION
## Summary
- raise the consent modal overlay to the maximum stacking context so it can't be hidden by other UI layers
- give the modal itself an explicit z-index so it always renders above the overlay backdrop

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deb322019c832f83c97b33fb160882