### PR TITLE
feat: auto-populate script blocking defaults and alerts

### DIFF
--- a/fp-privacy-cookie-policy/assets/css/banner.css
+++ b/fp-privacy-cookie-policy/assets/css/banner.css
@@ -1,13 +1,14 @@
 :root {
---fp-privacy-surface_bg: #0b1220;
---fp-privacy-surface_text: #ffffff;
---fp-privacy-button_primary_bg: #4c7cf6;
---fp-privacy-button_primary_tx: #ffffff;
---fp-privacy-button_secondary_bg: #e5e7eb;
---fp-privacy-button_secondary_tx: #111827;
---fp-privacy-link: #2563eb;
---fp-privacy-border: #d1d5db;
---fp-privacy-focus: #3b82f6;
+    --fp-privacy-surface_bg: #f9fafb;
+    --fp-privacy-surface_text: #1f2937;
+    --fp-privacy-button_primary_bg: #2563eb;
+    --fp-privacy-button_primary_tx: #ffffff;
+    --fp-privacy-button_secondary_bg: #ffffff;
+    --fp-privacy-button_secondary_tx: #1f2937;
+    --fp-privacy-link: #1d4ed8;
+    --fp-privacy-border: #d1d5db;
+    --fp-privacy-focus: #2563eb;
+    --fp-privacy-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
 }
 
 #fp-privacy-banner-root,
@@ -16,37 +17,41 @@ font-family: inherit;
 }
 
 .fp-privacy-banner {
-position: fixed;
-left: 50%;
-transform: translateX(-50%);
-z-index: 99999;
-max-width: 640px;
-background: var(--fp-privacy-surface_bg);
-color: var(--fp-privacy-surface_text);
-border-radius: 12px;
-padding: 24px;
-box-shadow: 0 20px 40px rgba(11, 18, 32, 0.25);
-border: 1px solid var(--fp-privacy-border);
-line-height: 1.6;
+    position: fixed;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 99999;
+    max-width: 640px;
+    background: var(--fp-privacy-surface_bg);
+    color: var(--fp-privacy-surface_text);
+    border-radius: 18px;
+    padding: 20px 24px;
+    box-shadow: var(--fp-privacy-shadow);
+    border: 1px solid var(--fp-privacy-border);
+    line-height: 1.6;
+    backdrop-filter: blur(12px);
 }
 
 .fp-privacy-banner h2 {
-margin-top: 0;
-font-size: 1.25rem;
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+    font-size: 1.1rem;
+    font-weight: 600;
 }
 
 .fp-privacy-banner p {
-margin-bottom: 1rem;
+    margin-bottom: 1rem;
+    font-size: 0.95rem;
 }
 
 .fp-privacy-revision-notice {
-margin-bottom: 1rem;
-padding: 12px 16px;
-border-radius: 8px;
-background: rgba(255, 255, 255, 0.12);
-border: 1px solid var(--fp-privacy-border);
-font-weight: 600;
-color: inherit;
+    margin-bottom: 1rem;
+    padding: 10px 16px;
+    border-radius: 10px;
+    background: rgba(37, 99, 235, 0.08);
+    border: 1px solid rgba(37, 99, 235, 0.18);
+    font-weight: 600;
+    color: inherit;
 }
 
 .fp-privacy-banner-buttons {
@@ -56,33 +61,50 @@ gap: 12px;
 }
 
 .fp-privacy-button {
-cursor: pointer;
-border-radius: 6px;
-font-weight: 600;
-padding: 0.6rem 1.4rem;
-border: 2px solid transparent;
-transition: background 0.2s ease, color 0.2s ease;
+    cursor: pointer;
+    border-radius: 999px;
+    font-weight: 600;
+    padding: 0.6rem 1.4rem;
+    border: 1px solid transparent;
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
 }
 
 .fp-privacy-button-primary {
-background: var(--fp-privacy-button_primary_bg);
-color: var(--fp-privacy-button_primary_tx);
+    background: var(--fp-privacy-button_primary_bg);
+    color: var(--fp-privacy-button_primary_tx);
+    border-color: transparent;
 }
 
 .fp-privacy-button-primary:focus,
 .fp-privacy-button-secondary:focus {
-outline: 3px solid var(--fp-privacy-focus);
-outline-offset: 2px;
+    outline: 3px solid var(--fp-privacy-focus);
+    outline-offset: 2px;
 }
 
 .fp-privacy-button-secondary {
-background: var(--fp-privacy-button_secondary_bg);
-color: var(--fp-privacy-button_secondary_tx);
+    background: var(--fp-privacy-button_secondary_bg);
+    color: var(--fp-privacy-button_secondary_tx);
+    border-color: var(--fp-privacy-border);
+}
+
+.fp-privacy-button:hover {
+    filter: brightness(0.95);
+}
+
+.fp-privacy-button-secondary:hover {
+    background: #f3f4f6;
 }
 
 .fp-privacy-link {
-color: var(--fp-privacy-link);
-text-decoration: underline;
+    color: var(--fp-privacy-link);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.fp-privacy-link:hover,
+.fp-privacy-link:focus {
+    text-decoration: underline;
 }
 
 .fp-privacy-modal-overlay {
@@ -187,6 +209,28 @@ font-size: 0.875rem;
 background: rgba(37, 99, 235, 0.1);
 padding: 1rem;
 border-radius: 8px;
+}
+
+.fp-privacy-blocked {
+    border: 1px solid var(--fp-privacy-border, #d1d5db);
+    background-color: rgba(249, 250, 251, 0.92);
+    color: var(--fp-privacy-surface_text, #111827);
+    padding: 20px;
+    text-align: center;
+    border-radius: 12px;
+    margin: 24px 0;
+}
+
+.fp-privacy-blocked p {
+    margin: 0 0 12px;
+}
+
+.fp-privacy-blocked .button {
+    margin: 0 auto;
+}
+
+.fp-privacy-style-placeholder {
+    display: none;
 }
 
 @media (max-width: 782px) {

--- a/fp-privacy-cookie-policy/src/Admin/IntegrationAudit.php
+++ b/fp-privacy-cookie-policy/src/Admin/IntegrationAudit.php
@@ -1,0 +1,464 @@
+<?php
+/**
+ * Scheduled detector audit and admin notices.
+ *
+ * @package FP\Privacy\Admin
+ */
+
+namespace FP\Privacy\Admin;
+
+use FP\Privacy\Utils\Options;
+
+use const DAY_IN_SECONDS;
+use function _n;
+use function __;
+use function count;
+use function esc_html;
+use function esc_html__;
+use function esc_html_e;
+use function esc_url;
+use function get_bloginfo;
+use function get_option;
+use function home_url;
+use function implode;
+use function is_array;
+use function number_format_i18n;
+use function sanitize_email;
+use function time;
+use function wp_json_encode;
+use function wp_mail;
+use function wp_date;
+
+/**
+ * Monitors integration changes and alerts administrators.
+ */
+class IntegrationAudit {
+    const EMAIL_COOLDOWN = DAY_IN_SECONDS;
+
+    /**
+     * Options handler.
+     *
+     * @var Options
+     */
+    private $options;
+
+    /**
+     * Policy generator.
+     *
+     * @var PolicyGenerator
+     */
+    private $generator;
+
+    /**
+     * Constructor.
+     *
+     * @param Options         $options   Options handler.
+     * @param PolicyGenerator $generator Policy generator.
+     */
+    public function __construct( Options $options, PolicyGenerator $generator ) {
+        $this->options   = $options;
+        $this->generator = $generator;
+    }
+
+    /**
+     * Register hooks.
+     *
+     * @return void
+     */
+    public function hooks() {
+        \add_action( 'fp_privacy_detector_audit', array( $this, 'run_audit' ) );
+        \add_action( 'admin_notices', array( $this, 'render_notice' ) );
+        \add_action( 'network_admin_notices', array( $this, 'render_notice' ) );
+        \add_action( 'fp_privacy_snapshots_refreshed', array( $this, 'handle_snapshots_refreshed' ) );
+    }
+
+    /**
+     * Execute scheduled audit and persist alert metadata.
+     *
+     * @return void
+     */
+    public function run_audit() {
+        $current   = $this->generator->snapshot( true );
+        $snapshots = $this->options->get( 'snapshots', array() );
+        $previous  = array();
+
+        if ( is_array( $snapshots ) && isset( $snapshots['services']['detected'] ) && is_array( $snapshots['services']['detected'] ) ) {
+            $previous = $snapshots['services']['detected'];
+        }
+
+        $this->options->prime_script_rules_from_services( $current );
+        $diff      = $this->diff_services( $previous, $current );
+        $timestamp = time();
+        $alert     = $this->options->get_detector_alert();
+
+        if ( empty( $diff['added'] ) && empty( $diff['removed'] ) ) {
+            $alert['active']       = false;
+            $alert['added']        = array();
+            $alert['removed']      = array();
+            $alert['detected_at']  = 0;
+            $alert['last_checked'] = $timestamp;
+            $this->options->set_detector_alert( $alert );
+
+            return;
+        }
+
+        $alert['active']       = true;
+        $alert['detected_at']  = $timestamp;
+        $alert['last_checked'] = $timestamp;
+        $alert['added']        = $this->summarize_services( $diff['added'] );
+        $alert['removed']      = $this->summarize_services( $diff['removed'] );
+
+        $this->options->set_detector_alert( $alert );
+        $this->maybe_send_email_alert( $alert );
+    }
+
+    /**
+     * Render the integration change notice when required.
+     *
+     * @return void
+     */
+    public function render_notice() {
+        if ( ! \current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        $alert = $this->options->get_detector_alert();
+
+        if ( empty( $alert['active'] ) ) {
+            return;
+        }
+
+        $added_count   = isset( $alert['added'] ) && is_array( $alert['added'] ) ? count( $alert['added'] ) : 0;
+        $removed_count = isset( $alert['removed'] ) && is_array( $alert['removed'] ) ? count( $alert['removed'] ) : 0;
+        $summary_parts = array();
+
+        if ( $added_count ) {
+            $summary_parts[] = sprintf(
+                _n( '%s new service detected', '%s new services detected', $added_count, 'fp-privacy' ),
+                number_format_i18n( $added_count )
+            );
+        }
+
+        if ( $removed_count ) {
+            $summary_parts[] = sprintf(
+                _n( '%s service missing', '%s services missing', $removed_count, 'fp-privacy' ),
+                number_format_i18n( $removed_count )
+            );
+        }
+
+        $detected_at = '';
+        if ( ! empty( $alert['detected_at'] ) ) {
+            $detected_at = \wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), (int) $alert['detected_at'] );
+        }
+
+        $editor_url = \admin_url( 'admin.php?page=fp-privacy-policy-editor' );
+        $added_list = $this->format_services_list( isset( $alert['added'] ) ? $alert['added'] : array() );
+        $removed_list = $this->format_services_list( isset( $alert['removed'] ) ? $alert['removed'] : array() );
+        ?>
+        <div class="notice notice-warning fp-privacy-detector-alert">
+            <p>
+                <?php
+                if ( $detected_at ) {
+                    printf(
+                        '<strong>%s</strong> %s ',
+                        esc_html__( 'Integration changes detected', 'fp-privacy' ),
+                        esc_html( sprintf( __( 'on %s', 'fp-privacy' ), $detected_at ) )
+                    );
+                } else {
+                    printf( '<strong>%s</strong> ', esc_html__( 'Integration changes detected', 'fp-privacy' ) );
+                }
+
+                if ( ! empty( $summary_parts ) ) {
+                    echo esc_html( implode( ' · ', $summary_parts ) );
+                }
+                ?>
+            </p>
+            <?php if ( $added_list ) : ?>
+                <p><strong><?php esc_html_e( 'New:', 'fp-privacy' ); ?></strong> <?php echo esc_html( $added_list ); ?></p>
+            <?php endif; ?>
+            <?php if ( $removed_list ) : ?>
+                <p><strong><?php esc_html_e( 'Removed:', 'fp-privacy' ); ?></strong> <?php echo esc_html( $removed_list ); ?></p>
+            <?php endif; ?>
+            <p>
+                <a class="button button-primary" href="<?php echo esc_url( $editor_url ); ?>">
+                    <?php esc_html_e( 'Review in policy editor', 'fp-privacy' ); ?>
+                </a>
+                <a class="button" href="<?php echo esc_url( \admin_url( 'admin.php?page=fp-privacy-tools' ) ); ?>">
+                    <?php esc_html_e( 'Open tools', 'fp-privacy' ); ?>
+                </a>
+            </p>
+        </div>
+        <?php
+    }
+
+    /**
+     * Reset alert metadata once snapshots are refreshed manually.
+     *
+     * @return void
+     */
+    public function handle_snapshots_refreshed() {
+        $alert                = $this->options->get_default_detector_alert();
+        $alert['last_checked'] = time();
+        $this->options->set_detector_alert( $alert );
+    }
+
+    /**
+     * Send email notifications when alerts become active.
+     *
+     * @param array<string, mixed> $alert Alert payload.
+     *
+     * @return void
+     */
+    private function maybe_send_email_alert( array $alert ) {
+        $settings = $this->options->get_detector_notifications();
+
+        if ( empty( $settings['email'] ) ) {
+            return;
+        }
+
+        $now       = time();
+        $last_sent = isset( $settings['last_sent'] ) ? (int) $settings['last_sent'] : 0;
+
+        if ( $last_sent && ( $now - $last_sent ) < self::EMAIL_COOLDOWN ) {
+            return;
+        }
+
+        $recipients = array();
+
+        if ( isset( $settings['recipients'] ) && is_array( $settings['recipients'] ) ) {
+            foreach ( $settings['recipients'] as $recipient ) {
+                $email = sanitize_email( $recipient );
+
+                if ( '' === $email || in_array( $email, $recipients, true ) ) {
+                    continue;
+                }
+
+                $recipients[] = $email;
+            }
+        }
+
+        if ( empty( $recipients ) ) {
+            $admin_email = sanitize_email( get_option( 'admin_email' ) );
+
+            if ( '' !== $admin_email ) {
+                $recipients[] = $admin_email;
+            }
+        }
+
+        if ( empty( $recipients ) ) {
+            return;
+        }
+
+        $site_name = trim( (string) get_bloginfo( 'name' ) );
+
+        if ( '' === $site_name ) {
+            $site_name = home_url();
+        }
+
+        $subject = sprintf( __( '[%s] Integration changes detected', 'fp-privacy' ), $site_name );
+
+        $lines = array();
+        $lines[] = sprintf( __( 'Integration monitoring detected changes on %s.', 'fp-privacy' ), $site_name );
+
+        if ( ! empty( $alert['detected_at'] ) ) {
+            $lines[] = sprintf(
+                __( 'Detected at: %s', 'fp-privacy' ),
+                wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), (int) $alert['detected_at'] )
+            );
+        }
+
+        if ( ! empty( $alert['added'] ) ) {
+            $added_block = $this->format_services_for_email( $alert['added'] );
+
+            if ( $added_block ) {
+                $lines[] = __( 'New services:', 'fp-privacy' );
+                $lines[] = $added_block;
+            }
+        }
+
+        if ( ! empty( $alert['removed'] ) ) {
+            $removed_block = $this->format_services_for_email( $alert['removed'] );
+
+            if ( $removed_block ) {
+                $lines[] = __( 'Removed services:', 'fp-privacy' );
+                $lines[] = $removed_block;
+            }
+        }
+
+        $lines[] = sprintf( __( 'Policy editor: %s', 'fp-privacy' ), \admin_url( 'admin.php?page=fp-privacy-policy-editor' ) );
+        $lines[] = sprintf( __( 'Tools dashboard: %s', 'fp-privacy' ), \admin_url( 'admin.php?page=fp-privacy-tools' ) );
+
+        $message = implode( "\n\n", array_filter( $lines ) );
+
+        if ( wp_mail( $recipients, $subject, $message ) ) {
+            $this->options->update_detector_notifications(
+                array(
+                    'last_sent' => $now,
+                )
+            );
+        }
+    }
+
+    /**
+     * Format services summary for email output.
+     *
+     * @param array<int, array<string, string>> $services Services summary.
+     *
+     * @return string
+     */
+    private function format_services_for_email( array $services ) {
+        if ( empty( $services ) ) {
+            return '';
+        }
+
+        $lines = array();
+
+        foreach ( $services as $service ) {
+            if ( ! is_array( $service ) ) {
+                continue;
+            }
+
+            $label = $service['name'] ?: $service['slug'];
+
+            if ( ! empty( $service['provider'] ) ) {
+                $label .= ' — ' . $service['provider'];
+            }
+
+            if ( ! empty( $service['category'] ) ) {
+                $label .= ' [' . $service['category'] . ']';
+            }
+
+            $lines[] = '- ' . $label;
+        }
+
+        return implode( "\n", $lines );
+    }
+
+    /**
+     * Compare previous and current detector output.
+     *
+     * @param array<int, array<string, mixed>> $previous Previous snapshot.
+     * @param array<int, array<string, mixed>> $current  Current snapshot.
+     *
+     * @return array{added:array<int, array<string, mixed>>, removed:array<int, array<string, mixed>>}
+     */
+    private function diff_services( array $previous, array $current ) {
+        $previous_indexed = $this->index_services( $previous );
+        $current_indexed  = $this->index_services( $current );
+
+        $added = array();
+        foreach ( $current_indexed as $key => $service ) {
+            if ( ! isset( $previous_indexed[ $key ] ) ) {
+                $added[] = $service;
+            }
+        }
+
+        $removed = array();
+        foreach ( $previous_indexed as $key => $service ) {
+            if ( ! isset( $current_indexed[ $key ] ) ) {
+                $removed[] = $service;
+            }
+        }
+
+        return array(
+            'added'   => $added,
+            'removed' => $removed,
+        );
+    }
+
+    /**
+     * Index services by a stable key for diffing.
+     *
+     * @param array<int, array<string, mixed>> $services Services list.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function index_services( array $services ) {
+        $indexed = array();
+
+        foreach ( $services as $service ) {
+            if ( ! is_array( $service ) ) {
+                continue;
+            }
+
+            $slug = isset( $service['slug'] ) ? \sanitize_key( $service['slug'] ) : '';
+            $name = isset( $service['name'] ) ? \sanitize_text_field( $service['name'] ) : '';
+            $provider = isset( $service['provider'] ) ? \sanitize_text_field( $service['provider'] ) : '';
+
+            $key = $slug;
+
+            if ( '' === $key && '' !== $name ) {
+                $key = \sanitize_key( $name . '-' . $provider );
+            }
+
+            if ( '' === $key ) {
+                $key = \md5( (string) wp_json_encode( $service ) );
+            }
+
+            $indexed[ $key ] = $service;
+        }
+
+        return $indexed;
+    }
+
+    /**
+     * Normalize services for alert summaries.
+     *
+     * @param array<int, array<string, mixed>> $services Services list.
+     *
+     * @return array<int, array<string, string>>
+     */
+    private function summarize_services( array $services ) {
+        $summaries = array();
+
+        foreach ( $services as $service ) {
+            if ( ! is_array( $service ) ) {
+                continue;
+            }
+
+            $summaries[] = array(
+                'slug'     => \sanitize_key( $service['slug'] ?? '' ),
+                'name'     => \sanitize_text_field( $service['name'] ?? '' ),
+                'category' => \sanitize_key( $service['category'] ?? '' ),
+                'provider' => \sanitize_text_field( $service['provider'] ?? '' ),
+            );
+        }
+
+        return $summaries;
+    }
+
+    /**
+     * Format services list for the admin notice.
+     *
+     * @param array<int, array<string, string>> $services Services summary.
+     *
+     * @return string
+     */
+    private function format_services_list( array $services ) {
+        if ( empty( $services ) ) {
+            return '';
+        }
+
+        $entries = array();
+        $slice   = array_slice( $services, 0, 3 );
+
+        foreach ( $slice as $service ) {
+            $label = $service['name'] ?: $service['slug'];
+
+            if ( $service['provider'] ) {
+                $label .= ' — ' . $service['provider'];
+            }
+
+            $entries[] = $label;
+        }
+
+        if ( count( $services ) > 3 ) {
+            $entries[] = sprintf(
+                __( 'and %s more', 'fp-privacy' ),
+                number_format_i18n( count( $services ) - 3 )
+            );
+        }
+
+        return implode( ', ', $entries );
+    }
+}

--- a/fp-privacy-cookie-policy/src/Admin/PolicyEditor.php
+++ b/fp-privacy-cookie-policy/src/Admin/PolicyEditor.php
@@ -46,9 +46,9 @@ $this->generator = $generator;
  * @return void
  */
 public function hooks() {
-\add_action( 'fp_privacy_admin_page_policy_editor', array( $this, 'render_page' ) );
-\add_action( 'admin_post_fp_privacy_save_policy', array( $this, 'handle_save' ) );
-\add_action( 'admin_post_fp_privacy_regenerate_policy', array( $this, 'handle_regenerate' ) );
+    \add_action( 'fp_privacy_admin_page_policy_editor', array( $this, 'render_page' ) );
+    \add_action( 'admin_post_fp_privacy_save_policy', array( $this, 'handle_save' ) );
+    \add_action( 'admin_post_fp_privacy_regenerate_policy', array( $this, 'handle_regenerate' ) );
 }
 
 /**
@@ -57,24 +57,28 @@ public function hooks() {
  * @return void
  */
 public function render_page() {
-if ( ! \current_user_can( 'manage_options' ) ) {
-\wp_die( \esc_html__( 'Permission denied.', 'fp-privacy' ) );
-}
+    if ( ! \current_user_can( 'manage_options' ) ) {
+        \wp_die( \esc_html__( 'Permission denied.', 'fp-privacy' ) );
+    }
 
-$languages = $this->options->get_languages();
-if ( empty( $languages ) ) {
-$languages = array( \get_locale() );
-}
+    $this->options->ensure_pages_exist();
 
-$privacy_posts = array();
-$cookie_posts  = array();
+    $languages = $this->options->get_languages();
+    if ( empty( $languages ) ) {
+        $languages = array( \get_locale() );
+    }
 
-foreach ( $languages as $language ) {
-    $privacy_id              = $this->options->get_page_id( 'privacy_policy', $language );
-    $cookie_id               = $this->options->get_page_id( 'cookie_policy', $language );
-    $privacy_posts[ $language ] = $privacy_id ? \get_post( $privacy_id ) : null;
-    $cookie_posts[ $language ]  = $cookie_id ? \get_post( $cookie_id ) : null;
-}
+    $this->maybe_generate_documents( $languages );
+
+    $privacy_posts = array();
+    $cookie_posts  = array();
+
+    foreach ( $languages as $language ) {
+        $privacy_id              = $this->options->get_page_id( 'privacy_policy', $language );
+        $cookie_id               = $this->options->get_page_id( 'cookie_policy', $language );
+        $privacy_posts[ $language ] = $privacy_id ? \get_post( $privacy_id ) : null;
+        $cookie_posts[ $language ]  = $cookie_id ? \get_post( $cookie_id ) : null;
+    }
 ?>
 <div class="wrap fp-privacy-policy-editor">
 <h1><?php \esc_html_e( 'Policy editor', 'fp-privacy' ); ?></h1>
@@ -123,48 +127,48 @@ foreach ( $languages as $language ) {
  * @return void
  */
 public function handle_save() {
-if ( ! \current_user_can( 'manage_options' ) ) {
-\wp_die( \esc_html__( 'Permission denied.', 'fp-privacy' ) );
-}
-
-\check_admin_referer( 'fp_privacy_save_policy', 'fp_privacy_policy_nonce' );
-
-$privacy_contents = isset( $_POST['privacy_content'] ) ? \wp_unslash( $_POST['privacy_content'] ) : array();
-$cookie_contents  = isset( $_POST['cookie_content'] ) ? \wp_unslash( $_POST['cookie_content'] ) : array();
-
-$languages = $this->options->get_languages();
-if ( empty( $languages ) ) {
-$languages = array( \get_locale() );
-}
-
-foreach ( $languages as $language ) {
-    $language    = $this->options->normalize_language( $language );
-    $privacy_id  = $this->options->get_page_id( 'privacy_policy', $language );
-    $cookie_id   = $this->options->get_page_id( 'cookie_policy', $language );
-    $privacy_body = isset( $privacy_contents[ $language ] ) ? $privacy_contents[ $language ] : '';
-    $cookie_body  = isset( $cookie_contents[ $language ] ) ? $cookie_contents[ $language ] : '';
-
-    if ( $privacy_id ) {
-        \wp_update_post(
-            array(
-                'ID'           => $privacy_id,
-                'post_content' => $privacy_body,
-            )
-        );
+    if ( ! \current_user_can( 'manage_options' ) ) {
+        \wp_die( \esc_html__( 'Permission denied.', 'fp-privacy' ) );
     }
 
-    if ( $cookie_id ) {
-        \wp_update_post(
-            array(
-                'ID'           => $cookie_id,
-                'post_content' => $cookie_body,
-            )
-        );
-    }
-}
+    \check_admin_referer( 'fp_privacy_save_policy', 'fp_privacy_policy_nonce' );
 
-\wp_safe_redirect( \add_query_arg( 'policy-updated', '1', \wp_get_referer() ) );
-exit;
+    $privacy_contents = isset( $_POST['privacy_content'] ) ? \wp_unslash( $_POST['privacy_content'] ) : array();
+    $cookie_contents  = isset( $_POST['cookie_content'] ) ? \wp_unslash( $_POST['cookie_content'] ) : array();
+
+    $languages = $this->options->get_languages();
+    if ( empty( $languages ) ) {
+        $languages = array( \get_locale() );
+    }
+
+    foreach ( $languages as $language ) {
+        $language     = $this->options->normalize_language( $language );
+        $privacy_id   = $this->options->get_page_id( 'privacy_policy', $language );
+        $cookie_id    = $this->options->get_page_id( 'cookie_policy', $language );
+        $privacy_body = isset( $privacy_contents[ $language ] ) ? $privacy_contents[ $language ] : '';
+        $cookie_body  = isset( $cookie_contents[ $language ] ) ? $cookie_contents[ $language ] : '';
+
+        if ( $privacy_id ) {
+            \wp_update_post(
+                array(
+                    'ID'           => $privacy_id,
+                    'post_content' => $privacy_body,
+                )
+            );
+        }
+
+        if ( $cookie_id ) {
+            \wp_update_post(
+                array(
+                    'ID'           => $cookie_id,
+                    'post_content' => $cookie_body,
+                )
+            );
+        }
+    }
+
+    \wp_safe_redirect( \add_query_arg( 'policy-updated', '1', \wp_get_referer() ) );
+    exit;
 }
 
 
@@ -174,84 +178,189 @@ exit;
  * @return void
  */
 public function handle_regenerate() {
-if ( ! \current_user_can( 'manage_options' ) ) {
-\wp_die( \esc_html__( 'Permission denied.', 'fp-privacy' ) );
-}
+    if ( ! \current_user_can( 'manage_options' ) ) {
+        \wp_die( \esc_html__( 'Permission denied.', 'fp-privacy' ) );
+    }
 
-\check_admin_referer( 'fp_privacy_regenerate_policy', 'fp_privacy_regenerate_nonce' );
+    \check_admin_referer( 'fp_privacy_regenerate_policy', 'fp_privacy_regenerate_nonce' );
 
-$this->options->ensure_pages_exist();
+    $this->options->ensure_pages_exist();
 
-$languages = $this->options->get_languages();
-if ( empty( $languages ) ) {
-$languages = array( \get_locale() );
-}
+    $languages = $this->options->get_languages();
+    if ( empty( $languages ) ) {
+        $languages = array( \get_locale() );
+    }
 
-foreach ( $languages as $language ) {
-    $language    = $this->options->normalize_language( $language );
-    $privacy_id  = $this->options->get_page_id( 'privacy_policy', $language );
-    $cookie_id   = $this->options->get_page_id( 'cookie_policy', $language );
+    $generated_privacy = array();
+    $generated_cookie  = array();
 
-    $privacy = $this->generator->generate_privacy_policy( $language );
-    $cookie  = $this->generator->generate_cookie_policy( $language );
+    foreach ( $languages as $language ) {
+        $language   = $this->options->normalize_language( $language );
+        $privacy_id = $this->options->get_page_id( 'privacy_policy', $language );
+        $cookie_id  = $this->options->get_page_id( 'cookie_policy', $language );
 
-    if ( $privacy_id ) {
-        \wp_update_post(
-            array(
-                'ID'           => $privacy_id,
-                'post_content' => $privacy,
-            )
+        $privacy = $this->generator->generate_privacy_policy( $language );
+        $cookie  = $this->generator->generate_cookie_policy( $language );
+
+        $generated_privacy[ $language ] = $privacy;
+        $generated_cookie[ $language ]  = $cookie;
+
+        if ( $privacy_id ) {
+            \wp_update_post(
+                array(
+                    'ID'           => $privacy_id,
+                    'post_content' => $privacy,
+                )
+            );
+        }
+
+        if ( $cookie_id ) {
+            \wp_update_post(
+                array(
+                    'ID'           => $cookie_id,
+                    'post_content' => $cookie,
+                )
+            );
+        }
+    }
+
+    $this->options->bump_revision();
+
+    $timestamp       = time();
+    $services        = $this->generator->snapshot( true );
+    $this->options->prime_script_rules_from_services( $services );
+    $snapshots       = array(
+        'services' => array(
+            'detected'     => $services,
+            'generated_at' => $timestamp,
+        ),
+        'policies' => array(
+            'privacy' => array(),
+            'cookie'  => array(),
+        ),
+    );
+
+    foreach ( $generated_privacy as $lang => $content ) {
+        $snapshots['policies']['privacy'][ $lang ] = array(
+            'content'      => $content,
+            'generated_at' => $timestamp,
         );
     }
 
-    if ( $cookie_id ) {
-        \wp_update_post(
-            array(
-                'ID'           => $cookie_id,
-                'post_content' => $cookie,
-            )
+    foreach ( $generated_cookie as $lang => $content ) {
+        $snapshots['policies']['cookie'][ $lang ] = array(
+            'content'      => $content,
+            'generated_at' => $timestamp,
         );
+    }
+
+    $payload                    = $this->options->all();
+    $payload['snapshots']       = $snapshots;
+    $payload['detector_alert']  = \array_merge( $this->options->get_default_detector_alert(), array( 'last_checked' => $timestamp ) );
+
+    $this->options->set( $payload );
+
+    \do_action( 'fp_privacy_snapshots_refreshed', $snapshots );
+
+    \wp_safe_redirect( \add_query_arg( 'policy-regenerated', '1', \wp_get_referer() ) );
+    exit;
+}
+
+/**
+ * Ensure generated documents exist for each language.
+ *
+ * @param array<int, string> $languages Languages configured for the site.
+ *
+ * @return void
+ */
+private function maybe_generate_documents( array $languages ) {
+    foreach ( $languages as $language ) {
+        $language   = $this->options->normalize_language( $language );
+        $privacy_id = $this->options->get_page_id( 'privacy_policy', $language );
+        $cookie_id  = $this->options->get_page_id( 'cookie_policy', $language );
+
+        if ( $privacy_id ) {
+            $this->maybe_generate_document( $privacy_id, 'privacy', $language );
+        }
+
+        if ( $cookie_id ) {
+            $this->maybe_generate_document( $cookie_id, 'cookie', $language );
+        }
     }
 }
 
-$this->options->bump_revision();
-$this->options->set( $this->options->all() );
+/**
+ * Generate policy content when the stored page is empty or still using the shortcode placeholder.
+ *
+ * @param int    $post_id  Page identifier.
+ * @param string $type     Document type (privacy|cookie).
+ * @param string $language Normalized language code.
+ *
+ * @return void
+ */
+private function maybe_generate_document( $post_id, $type, $language ) {
+    $post = \get_post( $post_id );
 
-\wp_safe_redirect( \add_query_arg( 'policy-regenerated', '1', \wp_get_referer() ) );
-exit;
+    if ( ! ( $post instanceof \WP_Post ) ) {
+        return;
+    }
+
+    $current_content = trim( (string) $post->post_content );
+    $shortcode       = 'privacy' === $type ? 'fp_privacy_policy' : 'fp_cookie_policy';
+    $placeholder     = \sprintf( '[%1$s lang="%2$s"]', $shortcode, $language );
+
+    if ( '' !== $current_content && $current_content !== $placeholder ) {
+        return;
+    }
+
+    $generated = 'privacy' === $type
+        ? $this->generator->generate_privacy_policy( $language )
+        : $this->generator->generate_cookie_policy( $language );
+
+    $updated = \wp_update_post(
+        array(
+            'ID'           => $post->ID,
+            'post_content' => $generated,
+        ),
+        true
+    );
+
+    if ( ! \is_wp_error( $updated ) ) {
+        \delete_post_meta( $post->ID, Options::PAGE_MANAGED_META_KEY );
+    }
 }
 
 
-    /**
-     * Diff preview.
-     *
-     * @param array<int, string>        $languages     Active languages.
-     * @param array<string, \WP_Post?> $privacy_posts Privacy posts keyed by language.
-     * @param array<string, \WP_Post?> $cookie_posts  Cookie posts keyed by language.
-     *
-     * @return string
-     */
-    private function get_diff_preview( array $languages, array $privacy_posts, array $cookie_posts ) {
-$output = '';
+/**
+ * Diff preview.
+ *
+ * @param array<int, string>        $languages     Active languages.
+ * @param array<string, \WP_Post?> $privacy_posts Privacy posts keyed by language.
+ * @param array<string, \WP_Post?> $cookie_posts  Cookie posts keyed by language.
+ *
+ * @return string
+ */
+private function get_diff_preview( array $languages, array $privacy_posts, array $cookie_posts ) {
+    $output = '';
 
-foreach ( $languages as $language ) {
-    $language    = $this->options->normalize_language( $language );
-    $privacy_post = isset( $privacy_posts[ $language ] ) ? $privacy_posts[ $language ] : null;
-    $cookie_post  = isset( $cookie_posts[ $language ] ) ? $cookie_posts[ $language ] : null;
+    foreach ( $languages as $language ) {
+        $language     = $this->options->normalize_language( $language );
+        $privacy_post = isset( $privacy_posts[ $language ] ) ? $privacy_posts[ $language ] : null;
+        $cookie_post  = isset( $cookie_posts[ $language ] ) ? $cookie_posts[ $language ] : null;
 
-    $generated_privacy = $this->generator->generate_privacy_policy( $language );
-    $generated_cookie  = $this->generator->generate_cookie_policy( $language );
+        $generated_privacy = $this->generator->generate_privacy_policy( $language );
+        $generated_cookie  = $this->generator->generate_cookie_policy( $language );
 
-    $privacy_current = $privacy_post ? $privacy_post->post_content : '';
-    $cookie_current  = $cookie_post ? $cookie_post->post_content : '';
+        $privacy_current = $privacy_post ? $privacy_post->post_content : '';
+        $cookie_current  = $cookie_post ? $cookie_post->post_content : '';
 
-    $privacy_diff = \wp_text_diff( $privacy_current, $generated_privacy, array( 'title' => \sprintf( \__( 'Privacy policy diff (%s)', 'fp-privacy' ), $language ) ) );
-    $cookie_diff  = \wp_text_diff( $cookie_current, $generated_cookie, array( 'title' => \sprintf( \__( 'Cookie policy diff (%s)', 'fp-privacy' ), $language ) ) );
+        $privacy_diff = \wp_text_diff( $privacy_current, $generated_privacy, array( 'title' => \sprintf( \__( 'Privacy policy diff (%s)', 'fp-privacy' ), $language ) ) );
+        $cookie_diff  = \wp_text_diff( $cookie_current, $generated_cookie, array( 'title' => \sprintf( \__( 'Cookie policy diff (%s)', 'fp-privacy' ), $language ) ) );
 
-    $output .= $privacy_diff . $cookie_diff;
-}
+        $output .= $privacy_diff . $cookie_diff;
+    }
 
-return $output;
+    return $output;
 }
 
 }

--- a/fp-privacy-cookie-policy/src/Admin/Settings.php
+++ b/fp-privacy-cookie-policy/src/Admin/Settings.php
@@ -114,6 +114,18 @@ if ( ! \current_user_can( 'manage_options' ) ) {
         $default_texts_raw = isset( $default_options['banner_texts'][ $default_locale ] ) && \is_array( $default_options['banner_texts'][ $default_locale ] )
             ? $default_options['banner_texts'][ $default_locale ]
             : array();
+        $script_rules      = array();
+        $script_categories = array();
+
+        foreach ( $languages as $script_lang ) {
+            $normalized                      = $this->options->normalize_language( $script_lang );
+            $script_rules[ $normalized ]      = $this->options->get_script_rules_for_language( $normalized );
+            $script_categories[ $normalized ] = $this->options->get_categories_for_language( $normalized );
+        }
+        $notifications           = $this->options->get_detector_notifications();
+        $notification_recipients = isset( $notifications['recipients'] ) && \is_array( $notifications['recipients'] )
+            ? implode( ', ', $notifications['recipients'] )
+            : '';
 ?>
 <div class="wrap fp-privacy-settings">
 <h1><?php \esc_html_e( 'Privacy & Cookie Settings', 'fp-privacy' ); ?></h1>
@@ -216,19 +228,19 @@ $message    = $timestamp ? \sprintf( \__( 'Policies generated on %s may be outda
 <label>
 <span><?php \esc_html_e( 'Display type', 'fp-privacy' ); ?></span>
 <select name="banner_layout[type]">
-<option value="floating" <?php\selected( $options['banner_layout']['type'], 'floating' ); ?>><?php \esc_html_e( 'Floating', 'fp-privacy' ); ?></option>
-<option value="bar" <?php\selected( $options['banner_layout']['type'], 'bar' ); ?>><?php \esc_html_e( 'Bar', 'fp-privacy' ); ?></option>
+<option value="floating" <?php \selected( $options['banner_layout']['type'], 'floating' ); ?>><?php \esc_html_e( 'Floating', 'fp-privacy' ); ?></option>
+<option value="bar" <?php \selected( $options['banner_layout']['type'], 'bar' ); ?>><?php \esc_html_e( 'Bar', 'fp-privacy' ); ?></option>
 </select>
 </label>
 <label>
 <span><?php \esc_html_e( 'Position', 'fp-privacy' ); ?></span>
 <select name="banner_layout[position]">
-<option value="top" <?php\selected( $options['banner_layout']['position'], 'top' ); ?>><?php \esc_html_e( 'Top', 'fp-privacy' ); ?></option>
-<option value="bottom" <?php\selected( $options['banner_layout']['position'], 'bottom' ); ?>><?php \esc_html_e( 'Bottom', 'fp-privacy' ); ?></option>
+<option value="top" <?php \selected( $options['banner_layout']['position'], 'top' ); ?>><?php \esc_html_e( 'Top', 'fp-privacy' ); ?></option>
+<option value="bottom" <?php \selected( $options['banner_layout']['position'], 'bottom' ); ?>><?php \esc_html_e( 'Bottom', 'fp-privacy' ); ?></option>
 </select>
 </label>
 <label>
-<input type="checkbox" name="banner_layout[sync_modal_and_button]" value="1" <?php\checked( $options['banner_layout']['sync_modal_and_button'], true ); ?> />
+<input type="checkbox" name="banner_layout[sync_modal_and_button]" value="1" <?php \checked( $options['banner_layout']['sync_modal_and_button'], true ); ?> />
 <?php \esc_html_e( 'Synchronize modal and button palette', 'fp-privacy' ); ?>
 </label>
 </div>
@@ -249,8 +261,8 @@ $message    = $timestamp ? \sprintf( \__( 'Policies generated on %s may be outda
 <label>
 <span><?php echo \esc_html( ucwords( str_replace( '_', ' ', $key ) ) ); ?></span>
 <select name="consent_mode_defaults[<?php echo \esc_attr( $key ); ?>]">
-<option value="granted" <?php\selected( $value, 'granted' ); ?>><?php \esc_html_e( 'Granted', 'fp-privacy' ); ?></option>
-<option value="denied" <?php\selected( $value, 'denied' ); ?>><?php \esc_html_e( 'Denied', 'fp-privacy' ); ?></option>
+<option value="granted" <?php \selected( $value, 'granted' ); ?>><?php \esc_html_e( 'Granted', 'fp-privacy' ); ?></option>
+<option value="denied" <?php \selected( $value, 'denied' ); ?>><?php \esc_html_e( 'Denied', 'fp-privacy' ); ?></option>
 </select>
 </label>
 <?php endforeach; ?>
@@ -262,7 +274,7 @@ $message    = $timestamp ? \sprintf( \__( 'Policies generated on %s may be outda
 <input type="number" min="1" name="retention_days" value="<?php echo \esc_attr( $options['retention_days'] ); ?>" />
 </label>
 <label>
-<input type="checkbox" name="preview_mode" value="1" <?php\checked( $options['preview_mode'], true ); ?> />
+<input type="checkbox" name="preview_mode" value="1" <?php \checked( $options['preview_mode'], true ); ?> />
 <?php \esc_html_e( 'Enable preview mode (admins only)', 'fp-privacy' ); ?>
 </label>
 <p><?php echo \esc_html( \sprintf( \__( 'Current consent revision: %d', 'fp-privacy' ), $options['consent_revision'] ) ); ?></p>
@@ -277,6 +289,59 @@ $message    = $timestamp ? \sprintf( \__( 'Policies generated on %s may be outda
 <label><span><?php \esc_html_e( 'DPO email', 'fp-privacy' ); ?></span><input type="email" name="dpo_email" value="<?php echo \esc_attr( $options['dpo_email'] ); ?>" class="regular-text" /></label>
 <label><span><?php \esc_html_e( 'Privacy contact email', 'fp-privacy' ); ?></span><input type="email" name="privacy_email" value="<?php echo \esc_attr( $options['privacy_email'] ); ?>" class="regular-text" /></label>
 </div>
+
+<h2><?php \esc_html_e( 'Integration alerts', 'fp-privacy' ); ?></h2>
+<label>
+    <input type="checkbox" name="detector_notifications[email]" value="1" <?php \checked( ! empty( $notifications['email'] ) ); ?> />
+    <?php \esc_html_e( 'Send an email when new services are detected or existing ones disappear.', 'fp-privacy' ); ?>
+</label>
+<label>
+    <span><?php \esc_html_e( 'Notification recipients', 'fp-privacy' ); ?></span>
+    <input type="text" name="detector_notifications[recipients]" value="<?php echo \esc_attr( $notification_recipients ); ?>" class="regular-text" />
+    <span class="description"><?php \esc_html_e( 'Comma separated email addresses. Leave blank to use the site administrator email.', 'fp-privacy' ); ?></span>
+</label>
+
+<h2><?php \esc_html_e( 'Script blocking', 'fp-privacy' ); ?></h2>
+<p class="description"><?php \esc_html_e( 'Pause specific scripts, styles, or embeds until the visitor grants the corresponding consent category.', 'fp-privacy' ); ?></p>
+<p class="description"><?php \esc_html_e( 'Detected integrations prefill suggested handles and patterns; edit a category to override the automatic rules.', 'fp-privacy' ); ?></p>
+<?php foreach ( $languages as $script_lang ) :
+    $script_lang      = $this->options->normalize_language( $script_lang );
+    $rules            = isset( $script_rules[ $script_lang ] ) ? $script_rules[ $script_lang ] : array();
+    $categories_meta  = isset( $script_categories[ $script_lang ] ) ? $script_categories[ $script_lang ] : array();
+    ?>
+    <div class="fp-privacy-language-panel" data-lang="<?php echo \esc_attr( $script_lang ); ?>">
+        <h3><?php echo \esc_html( \sprintf( \__( 'Language: %s', 'fp-privacy' ), $script_lang ) ); ?></h3>
+        <?php foreach ( $categories_meta as $slug => $meta ) :
+            $category_rules = isset( $rules[ $slug ] ) && \is_array( $rules[ $slug ] ) ? $rules[ $slug ] : array();
+            $handles        = isset( $category_rules['script_handles'] ) && \is_array( $category_rules['script_handles'] ) ? implode( "\n", $category_rules['script_handles'] ) : '';
+            $style_handles  = isset( $category_rules['style_handles'] ) && \is_array( $category_rules['style_handles'] ) ? implode( "\n", $category_rules['style_handles'] ) : '';
+            $patterns       = isset( $category_rules['patterns'] ) && \is_array( $category_rules['patterns'] ) ? implode( "\n", $category_rules['patterns'] ) : '';
+            $iframes        = isset( $category_rules['iframes'] ) && \is_array( $category_rules['iframes'] ) ? implode( "\n", $category_rules['iframes'] ) : '';
+            ?>
+            <fieldset class="fp-privacy-script-category">
+                <legend><?php echo \esc_html( \sprintf( \__( '%s category', 'fp-privacy' ), $meta['label'] ) ); ?></legend>
+                <label>
+                    <span><?php \esc_html_e( 'Script handles to block (one per line)', 'fp-privacy' ); ?></span>
+                    <textarea name="scripts[<?php echo \esc_attr( $script_lang ); ?>][<?php echo \esc_attr( $slug ); ?>][script_handles]" rows="3" class="large-text"><?php echo \esc_textarea( $handles ); ?></textarea>
+                </label>
+                <label>
+                    <span><?php \esc_html_e( 'Style handles to block (one per line)', 'fp-privacy' ); ?></span>
+                    <textarea name="scripts[<?php echo \esc_attr( $script_lang ); ?>][<?php echo \esc_attr( $slug ); ?>][style_handles]" rows="2" class="large-text"><?php echo \esc_textarea( $style_handles ); ?></textarea>
+                </label>
+                <label>
+                    <span><?php \esc_html_e( 'Script source substrings', 'fp-privacy' ); ?></span>
+                    <textarea name="scripts[<?php echo \esc_attr( $script_lang ); ?>][<?php echo \esc_attr( $slug ); ?>][patterns]" rows="3" class="large-text"><?php echo \esc_textarea( $patterns ); ?></textarea>
+                    <span class="description"><?php \esc_html_e( 'Any script tag whose src contains one of these values will be paused until consent is granted.', 'fp-privacy' ); ?></span>
+                </label>
+                <label>
+                    <span><?php \esc_html_e( 'Iframe source substrings', 'fp-privacy' ); ?></span>
+                    <textarea name="scripts[<?php echo \esc_attr( $script_lang ); ?>][<?php echo \esc_attr( $slug ); ?>][iframes]" rows="3" class="large-text"><?php echo \esc_textarea( $iframes ); ?></textarea>
+                    <span class="description"><?php \esc_html_e( 'Iframes whose src contains one of these values will be replaced with a consent prompt.', 'fp-privacy' ); ?></span>
+                </label>
+            </fieldset>
+        <?php endforeach; ?>
+    </div>
+<?php endforeach; ?>
 
 <?php \submit_button( \__( 'Save settings', 'fp-privacy' ) ); ?>
 </form>
@@ -535,6 +600,11 @@ $payload = array(
 'privacy_email'         => isset( $_POST['privacy_email'] ) ? \wp_unslash( $_POST['privacy_email'] ) : '',
 'categories'            => $this->options->get( 'categories' ),
 'retention_days'        => isset( $_POST['retention_days'] ) ? (int) $_POST['retention_days'] : $this->options->get( 'retention_days' ),
+'scripts'               => isset( $_POST['scripts'] ) ? \wp_unslash( $_POST['scripts'] ) : array(),
+'detector_notifications' => array(
+    'email'      => isset( $_POST['detector_notifications']['email'] ),
+    'recipients' => isset( $_POST['detector_notifications']['recipients'] ) ? \wp_unslash( $_POST['detector_notifications']['recipients'] ) : '',
+),
 );
 
 $this->options->set( $payload );

--- a/fp-privacy-cookie-policy/src/Frontend/Banner.php
+++ b/fp-privacy-cookie-policy/src/Frontend/Banner.php
@@ -166,15 +166,15 @@ public function render_banner() {
      */
     private function build_palette_css( $palette, $sync_modal = false ) {
         $defaults = array(
-            'surface_bg'          => '#0B1220',
-            'surface_text'        => '#FFFFFF',
-            'button_primary_bg'   => '#4C7CF6',
+            'surface_bg'          => '#F9FAFB',
+            'surface_text'        => '#1F2937',
+            'button_primary_bg'   => '#2563EB',
             'button_primary_tx'   => '#FFFFFF',
-            'button_secondary_bg' => '#E5E7EB',
-            'button_secondary_tx' => '#111827',
-            'link'                => '#2563EB',
+            'button_secondary_bg' => '#FFFFFF',
+            'button_secondary_tx' => '#1F2937',
+            'link'                => '#1D4ED8',
             'border'              => '#D1D5DB',
-            'focus'               => '#3B82F6',
+            'focus'               => '#2563EB',
         );
 
         $palette = is_array( $palette ) ? array_merge( $defaults, $palette ) : $defaults;

--- a/fp-privacy-cookie-policy/src/Frontend/ScriptBlocker.php
+++ b/fp-privacy-cookie-policy/src/Frontend/ScriptBlocker.php
@@ -1,0 +1,438 @@
+<?php
+/**
+ * Blocks scripts and embeds until consent is granted.
+ *
+ * @package FP\Privacy\Frontend
+ */
+
+namespace FP\Privacy\Frontend;
+
+use FP\Privacy\Utils\Options;
+
+use function __;
+use function array_slice;
+use function base64_encode;
+use function esc_attr;
+use function esc_html;
+use function esc_html__;
+use function is_admin;
+use function is_array;
+use function preg_match;
+use function preg_replace_callback;
+use function sanitize_key;
+use function stripos;
+use function trim;
+
+/**
+ * Transforms matching assets into inert placeholders.
+ */
+class ScriptBlocker {
+    /**
+     * Options handler.
+     *
+     * @var Options
+     */
+    private $options;
+
+    /**
+     * Consent state handler.
+     *
+     * @var ConsentState
+     */
+    private $state;
+
+    /**
+     * Whether the component has been prepared.
+     *
+     * @var bool
+     */
+    private $prepared = false;
+
+    /**
+     * Current language.
+     *
+     * @var string
+     */
+    private $language = '';
+
+    /**
+     * Blocking rules.
+     *
+     * @var array<string, mixed>
+     */
+    private $rules = array();
+
+    /**
+     * Allowed categories map.
+     *
+     * @var array<string, bool>
+     */
+    private $allowed = array();
+
+    /**
+     * Category labels for placeholders.
+     *
+     * @var array<string, string>
+     */
+    private $category_labels = array();
+
+    /**
+     * Constructor.
+     *
+     * @param Options      $options Options handler.
+     * @param ConsentState $state   Consent state.
+     */
+    public function __construct( Options $options, ConsentState $state ) {
+        $this->options = $options;
+        $this->state   = $state;
+    }
+
+    /**
+     * Register hooks when not in the admin area.
+     *
+     * @return void
+     */
+    public function hooks() {
+        if ( is_admin() ) {
+            return;
+        }
+
+        \add_action( 'init', array( $this, 'prepare' ), 5 );
+        \add_filter( 'script_loader_tag', array( $this, 'filter_script_tag' ), 999, 3 );
+        \add_filter( 'style_loader_tag', array( $this, 'filter_style_tag' ), 999, 4 );
+        \add_filter( 'the_content', array( $this, 'filter_content' ), 9 );
+        \add_filter( 'widget_text_content', array( $this, 'filter_content' ), 9 );
+        \add_filter( 'widget_block_content', array( $this, 'filter_content' ), 9 );
+    }
+
+    /**
+     * Hydrate rules and state.
+     *
+     * @return void
+     */
+    public function prepare() {
+        if ( $this->prepared ) {
+            return;
+        }
+
+        $locale = '';
+
+        if ( \function_exists( '\\determine_locale' ) ) {
+            $locale = \determine_locale();
+        }
+
+        if ( '' === $locale && \function_exists( '\\get_locale' ) ) {
+            $locale = \get_locale();
+        }
+
+        $locale        = $this->options->normalize_language( $locale ?: 'en_US' );
+        $rules_by_cat  = $this->options->get_script_rules_for_language( $locale );
+        $categories    = $this->options->get_categories_for_language( $locale );
+        $frontend      = $this->state->get_frontend_state( $locale );
+        $consent_state = array();
+        $preview       = false;
+
+        if ( isset( $frontend['state'] ) && is_array( $frontend['state'] ) ) {
+            $preview = ! empty( $frontend['state']['preview_mode'] );
+
+            if ( isset( $frontend['state']['categories'] ) && is_array( $frontend['state']['categories'] ) ) {
+                $consent_state = $frontend['state']['categories'];
+            }
+        }
+
+        $script_handles = array();
+        $style_handles  = array();
+        $script_patterns = array();
+        $iframe_patterns = array();
+
+        foreach ( $rules_by_cat as $category => $rule_set ) {
+            if ( empty( $rule_set ) || ! is_array( $rule_set ) ) {
+                continue;
+            }
+
+            if ( ! empty( $rule_set['script_handles'] ) && is_array( $rule_set['script_handles'] ) ) {
+                foreach ( $rule_set['script_handles'] as $handle ) {
+                    $script_handles[ $handle ] = $category;
+                }
+            }
+
+            if ( ! empty( $rule_set['style_handles'] ) && is_array( $rule_set['style_handles'] ) ) {
+                foreach ( $rule_set['style_handles'] as $handle ) {
+                    $style_handles[ $handle ] = $category;
+                }
+            }
+
+            if ( ! empty( $rule_set['patterns'] ) && is_array( $rule_set['patterns'] ) ) {
+                foreach ( $rule_set['patterns'] as $pattern ) {
+                    $pattern = trim( $pattern );
+
+                    if ( '' === $pattern ) {
+                        continue;
+                    }
+
+                    $script_patterns[] = array(
+                        'pattern'  => $pattern,
+                        'category' => $category,
+                    );
+                }
+            }
+
+            if ( ! empty( $rule_set['iframes'] ) && is_array( $rule_set['iframes'] ) ) {
+                foreach ( $rule_set['iframes'] as $pattern ) {
+                    $pattern = trim( $pattern );
+
+                    if ( '' === $pattern ) {
+                        continue;
+                    }
+
+                    $iframe_patterns[] = array(
+                        'pattern'  => $pattern,
+                        'category' => $category,
+                    );
+                }
+            }
+        }
+
+        $this->language        = $locale;
+        $this->rules           = array(
+            'script_handles'  => $script_handles,
+            'style_handles'   => $style_handles,
+            'script_patterns' => $script_patterns,
+            'iframe_patterns' => $iframe_patterns,
+        );
+        $this->category_labels = array();
+        $this->allowed         = array();
+
+        foreach ( $categories as $slug => $meta ) {
+            $this->category_labels[ $slug ] = isset( $meta['label'] ) ? (string) $meta['label'] : $slug;
+
+            if ( $preview ) {
+                $this->allowed[ $slug ] = true;
+                continue;
+            }
+
+            if ( ! empty( $meta['locked'] ) ) {
+                $this->allowed[ $slug ] = true;
+                continue;
+            }
+
+            $this->allowed[ $slug ] = isset( $consent_state[ $slug ] ) ? (bool) $consent_state[ $slug ] : false;
+        }
+
+        $this->prepared = true;
+    }
+
+    /**
+     * Replace script tags when necessary.
+     *
+     * @param string $tag    Original tag HTML.
+     * @param string $handle Script handle.
+     * @param string $src    Source URL.
+     *
+     * @return string
+     */
+    public function filter_script_tag( $tag, $handle, $src ) {
+        $this->prepare();
+
+        if ( empty( $this->rules['script_handles'] ) && empty( $this->rules['script_patterns'] ) ) {
+            return $tag;
+        }
+
+        $category = '';
+        $normalized_handle = sanitize_key( $handle );
+
+        if ( '' !== $normalized_handle && isset( $this->rules['script_handles'][ $normalized_handle ] ) ) {
+            $category = $this->rules['script_handles'][ $normalized_handle ];
+        }
+
+        if ( '' === $category && '' !== $src ) {
+            $category = $this->match_pattern_category( $src, $this->rules['script_patterns'] );
+        }
+
+        if ( '' === $category || ! $this->should_block_category( $category ) ) {
+            return $tag;
+        }
+
+        return $this->build_placeholder( $tag, 'script', $category );
+    }
+
+    /**
+     * Replace style tags when necessary.
+     *
+     * @param string $tag    Original tag HTML.
+     * @param string $handle Style handle.
+     * @param string $href   Stylesheet href.
+     * @param string $media  Media attribute.
+     *
+     * @return string
+     */
+    public function filter_style_tag( $tag, $handle, $href, $media ) {
+        $this->prepare();
+
+        if ( empty( $this->rules['style_handles'] ) ) {
+            return $tag;
+        }
+
+        $normalized_handle = sanitize_key( $handle );
+
+        if ( '' === $normalized_handle || ! isset( $this->rules['style_handles'][ $normalized_handle ] ) ) {
+            return $tag;
+        }
+
+        $category = $this->rules['style_handles'][ $normalized_handle ];
+
+        if ( ! $this->should_block_category( $category ) ) {
+            return $tag;
+        }
+
+        return $this->build_placeholder( $tag, 'style', $category );
+    }
+
+    /**
+     * Filter post content to block inline scripts and iframes.
+     *
+     * @param string $content HTML content.
+     *
+     * @return string
+     */
+    public function filter_content( $content ) {
+        $this->prepare();
+
+        $result = $content;
+
+        if ( ! empty( $this->rules['script_patterns'] ) ) {
+            $result = preg_replace_callback(
+                '/<script\b[^>]*>.*?<\/script>/is',
+                function ( $matches ) {
+                    $tag = $matches[0];
+                    $category = '';
+
+                    if ( preg_match( '/src\s*=\s*"([^"]+)"/i', $tag, $src_match ) ) {
+                        $category = $this->match_pattern_category( $src_match[1], $this->rules['script_patterns'] );
+                    }
+
+                    if ( '' === $category || ! $this->should_block_category( $category ) ) {
+                        return $tag;
+                    }
+
+                    return $this->build_placeholder( $tag, 'script', $category );
+                },
+                $result
+            );
+        }
+
+        if ( ! empty( $this->rules['iframe_patterns'] ) ) {
+            $result = preg_replace_callback(
+                '/<iframe\b[^>]*>.*?<\/iframe>/is',
+                function ( $matches ) {
+                    $tag = $matches[0];
+                    $category = '';
+
+                    if ( preg_match( '/src\s*=\s*"([^"]+)"/i', $tag, $src_match ) ) {
+                        $category = $this->match_pattern_category( $src_match[1], $this->rules['iframe_patterns'] );
+                    }
+
+                    if ( '' === $category || ! $this->should_block_category( $category ) ) {
+                        return $tag;
+                    }
+
+                    return $this->build_placeholder( $tag, 'iframe', $category );
+                },
+                $result
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * Determine whether a category should be blocked.
+     *
+     * @param string $category Category slug.
+     *
+     * @return bool
+     */
+    private function should_block_category( $category ) {
+        if ( isset( $this->allowed[ $category ] ) ) {
+            return ! $this->allowed[ $category ];
+        }
+
+        return true;
+    }
+
+    /**
+     * Attempt to match a value against configured patterns.
+     *
+     * @param string $value    Candidate string.
+     * @param array  $patterns Pattern definitions.
+     *
+     * @return string
+     */
+    private function match_pattern_category( $value, $patterns ) {
+        if ( empty( $patterns ) || '' === $value ) {
+            return '';
+        }
+
+        foreach ( $patterns as $entry ) {
+            if ( empty( $entry['pattern'] ) || ! isset( $entry['category'] ) ) {
+                continue;
+            }
+
+            if ( false !== stripos( $value, $entry['pattern'] ) ) {
+                return (string) $entry['category'];
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Build placeholder markup for the provided HTML chunk.
+     *
+     * @param string $original Original HTML.
+     * @param string $type     Placeholder type (script|style|iframe).
+     * @param string $category Consent category.
+     *
+     * @return string
+     */
+    private function build_placeholder( $original, $type, $category ) {
+        $encoded = base64_encode( $original );
+
+        if ( false === $encoded ) {
+            return $original;
+        }
+
+        $label        = isset( $this->category_labels[ $category ] ) ? $this->category_labels[ $category ] : $category;
+        $category_attr = esc_attr( $category );
+        $encoded_attr  = esc_attr( $encoded );
+
+        if ( 'script' === $type ) {
+            return sprintf(
+                '<script type="text/plain" data-fp-privacy-blocked="script" data-fp-privacy-category="%1$s" data-fp-privacy-replace="%2$s"></script>',
+                $category_attr,
+                $encoded_attr
+            );
+        }
+
+        if ( 'style' === $type ) {
+            return sprintf(
+                '<span class="fp-privacy-style-placeholder" data-fp-privacy-blocked="style" data-fp-privacy-category="%1$s" data-fp-privacy-replace="%2$s"></span>',
+                $category_attr,
+                $encoded_attr
+            );
+        }
+
+        $message = sprintf(
+            __( 'Content blocked until %s consent is granted.', 'fp-privacy' ),
+            $label
+        );
+
+        return sprintf(
+            '<div class="fp-privacy-blocked" data-fp-privacy-blocked="iframe" data-fp-privacy-category="%1$s" data-fp-privacy-replace="%2$s"><p>%3$s</p><button type="button" class="button" data-fp-privacy-open="1">%4$s</button></div>',
+            $category_attr,
+            $encoded_attr,
+            esc_html( $message ),
+            esc_html__( 'Manage preferences', 'fp-privacy' )
+        );
+    }
+}

--- a/fp-privacy-cookie-policy/src/Integrations/DetectorRegistry.php
+++ b/fp-privacy-cookie-policy/src/Integrations/DetectorRegistry.php
@@ -114,7 +114,7 @@ return \wp_script_is( 'hotjar-tracking', 'enqueued' ) || defined( 'HOTJAR_SITE_I
 return defined( 'CLARITY_PROJECT_ID' ) || \has_action( 'wp_head', 'ms_clarity_tag' );
 },
 ),
-recaptcha        => array(
+        'recaptcha'        => array(
 'name'        => 'Google reCAPTCHA',
 'category'    => 'necessary',
 'provider'    => 'Google LLC',
@@ -128,7 +128,7 @@ recaptcha        => array(
 return \wp_script_is( 'google-recaptcha', 'enqueued' ) || defined( 'RECAPTCHA_SITE_KEY' );
 },
 ),
-youtube          => array(
+        'youtube'          => array(
 'name'        => 'YouTube embeds',
 'category'    => 'marketing',
 'provider'    => 'Google LLC',
@@ -166,7 +166,7 @@ youtube          => array(
 return defined( 'LI_AJAX' ) || \has_action( 'wp_head', 'linkedin_insight' );
 },
 ),
-tiktok           => array(
+        'tiktok'           => array(
 'name'        => 'TikTok Pixel',
 'category'    => 'marketing',
 'provider'    => 'TikTok Technology Limited',
@@ -523,5 +523,127 @@ return \apply_filters( 'fp_privacy_services_registry', $services );
         }
 
         return (int) $ttl;
+    }
+
+    /**
+     * Provide default blocking presets for known services.
+     *
+     * @return array<string, array<string, array<int, string>>>
+     */
+    public static function get_blocking_presets() {
+        return array(
+            'ga4'             => array(
+                'script_handles' => array( 'google-analytics', 'gtag' ),
+                'style_handles'  => array(),
+                'patterns'       => array(
+                    'googletagmanager.com/gtag/js',
+                    'google-analytics.com/analytics.js',
+                ),
+                'iframes'        => array(),
+            ),
+            'gtm'             => array(
+                'script_handles' => array( 'google-tag-manager' ),
+                'style_handles'  => array(),
+                'patterns'       => array(
+                    'googletagmanager.com/gtm.js',
+                ),
+                'iframes'        => array(
+                    'googletagmanager.com/ns.html',
+                ),
+            ),
+            'facebook_pixel'  => array(
+                'script_handles' => array( 'facebook-pixel' ),
+                'style_handles'  => array(),
+                'patterns'       => array(
+                    'connect.facebook.net/en_US/fbevents.js',
+                ),
+                'iframes'        => array(),
+            ),
+            'hotjar'          => array(
+                'script_handles' => array( 'hotjar-tracking' ),
+                'style_handles'  => array(),
+                'patterns'       => array(
+                    'static.hotjar.com',
+                    'script.hotjar.com',
+                ),
+                'iframes'        => array(),
+            ),
+            'clarity'         => array(
+                'script_handles' => array( 'ms-clarity' ),
+                'style_handles'  => array(),
+                'patterns'       => array(
+                    'www.clarity.ms/tag',
+                    'clarity.ms/tag',
+                ),
+                'iframes'        => array(),
+            ),
+            'recaptcha'       => array(
+                'script_handles' => array( 'google-recaptcha' ),
+                'style_handles'  => array(),
+                'patterns'       => array(
+                    'www.google.com/recaptcha',
+                    'www.gstatic.com/recaptcha',
+                ),
+                'iframes'        => array(
+                    'www.google.com/recaptcha',
+                ),
+            ),
+            'youtube'         => array(
+                'script_handles' => array(),
+                'style_handles'  => array(),
+                'patterns'       => array(
+                    'youtube.com/iframe_api',
+                    'ytimg.com/iframe_api',
+                ),
+                'iframes'        => array(
+                    'youtube.com/embed',
+                    'youtube-nocookie.com/embed',
+                ),
+            ),
+            'vimeo'           => array(
+                'script_handles' => array(),
+                'style_handles'  => array(),
+                'patterns'       => array(
+                    'player.vimeo.com/api/player.js',
+                ),
+                'iframes'        => array(
+                    'player.vimeo.com/video',
+                ),
+            ),
+            'linkedin'        => array(
+                'script_handles' => array( 'linkedin-insight' ),
+                'style_handles'  => array(),
+                'patterns'       => array(
+                    'snap.licdn.com/li.lms-analytics/insight.min.js',
+                ),
+                'iframes'        => array(),
+            ),
+            'tiktok'          => array(
+                'script_handles' => array( 'tiktok-pixel' ),
+                'style_handles'  => array(),
+                'patterns'       => array(
+                    'analytics.tiktok.com/i18n/pixel/events.js',
+                ),
+                'iframes'        => array(),
+            ),
+            'matomo'          => array(
+                'script_handles' => array( 'matomo-tracking' ),
+                'style_handles'  => array(),
+                'patterns'       => array(
+                    'matomo.js',
+                    'piwik.js',
+                ),
+                'iframes'        => array(),
+            ),
+            'pinterest'       => array(
+                'script_handles' => array( 'pinterest-tag' ),
+                'style_handles'  => array(),
+                'patterns'       => array(
+                    's.pinimg.com/ct/core.js',
+                    'ct.pinterest.com',
+                ),
+                'iframes'        => array(),
+            ),
+        );
     }
 }

--- a/fp-privacy-cookie-policy/templates/cookie-policy.php
+++ b/fp-privacy-cookie-policy/templates/cookie-policy.php
@@ -9,11 +9,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 exit;
 }
 
-$retention     = isset( $options['retention_days'] ) ? (int) $options['retention_days'] : 180;
-$generated_at  = isset( $generated_at ) ? (int) $generated_at : 0;
-$date_format   = (string) get_option( 'date_format' );
-$time_format   = (string) get_option( 'time_format' );
-$display_format = trim( $date_format . ' ' . $time_format );
+$retention       = isset( $options['retention_days'] ) ? (int) $options['retention_days'] : 180;
+$generated_at    = isset( $generated_at ) ? (int) $generated_at : 0;
+$date_format     = (string) get_option( 'date_format' );
+$time_format     = (string) get_option( 'time_format' );
+$display_format  = trim( $date_format . ' ' . $time_format );
 $categories_meta = isset( $categories_meta ) && is_array( $categories_meta ) ? $categories_meta : array();
 
 if ( ! function_exists( 'fp_privacy_format_service_cookies' ) ) {
@@ -111,14 +111,20 @@ if ( '' === $last_generated ) {
 }
 ?>
 <section class="fp-cookie-policy">
-<h2><?php echo esc_html__( 'About cookies', 'fp-privacy' ); ?></h2>
-<p><?php echo esc_html__( 'Cookies are small text files stored on your device. They allow us to remember your preferences, ensure the website works properly and measure performance. Some cookies are strictly necessary while others require your consent.', 'fp-privacy' ); ?></p>
+<h2><?php echo esc_html__( 'About cookies and tracking technologies', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'Cookies are small text files stored on your device together with similar technologies such as local storage or pixels. They enable core functionality, remember your preferences and help us measure interactions. Except for strictly necessary cookies, we only place cookies after obtaining your explicit consent in line with the GDPR and the ePrivacy Directive.', 'fp-privacy' ); ?></p>
+
+<h2><?php echo esc_html__( 'Legal framework', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'Cookie usage is based on your consent pursuant to Articles 6.1.a and 7 GDPR and the national implementation of the ePrivacy Directive. Evidence of consent is securely stored and may be provided to supervisory authorities upon request.', 'fp-privacy' ); ?></p>
 
 <h2><?php echo esc_html__( 'How we use cookies', 'fp-privacy' ); ?></h2>
-<p><?php echo esc_html__( 'We group cookies into categories so you can tailor your experience. You can update your preferences at any time using the cookie preferences button.', 'fp-privacy' ); ?></p>
+<p><?php echo esc_html__( 'We group cookies into categories so you can tailor your experience. Each category contains the services and technologies described in the tables below, including provider, purpose, cookie duration and links to external privacy information where available.', 'fp-privacy' ); ?></p>
 
 <h2><?php echo esc_html__( 'Retention of consent', 'fp-privacy' ); ?></h2>
 <p><?php echo esc_html( sprintf( __( 'Your consent choices are stored for %d days unless you change them earlier.', 'fp-privacy' ), $retention ) ); ?></p>
+
+<h2><?php echo esc_html__( 'Third-country transfers', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'Some providers may process data outside the EU/EEA. Where this occurs we rely on adequacy decisions or Standard Contractual Clauses combined with supplementary measures to ensure an equivalent level of protection.', 'fp-privacy' ); ?></p>
 
 <?php foreach ( $groups as $category => $services ) :
     $meta  = isset( $categories_meta[ $category ] ) && is_array( $categories_meta[ $category ] ) ? $categories_meta[ $category ] : array();
@@ -169,7 +175,10 @@ if ( '' === $last_generated ) {
 <?php endforeach; ?>
 
 <h2><?php echo esc_html__( 'Managing cookies', 'fp-privacy' ); ?></h2>
-<p><?php echo esc_html__( 'You can revisit your preferences using the cookie preferences button or adjust your browser settings to delete or block cookies. Blocking essential cookies may impact site functionality.', 'fp-privacy' ); ?></p>
+<p><?php echo esc_html__( 'You can revisit your preferences using the cookie preferences button available on every page or adjust your browser settings to delete or block cookies. Blocking essential cookies may impact site functionality. You can also withdraw consent at any time without affecting the lawfulness of processing carried out before withdrawal.', 'fp-privacy' ); ?></p>
+
+<h2><?php echo esc_html__( 'Your rights', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'For more information about how we handle personal data and how to exercise your rights of access, rectification, erasure, restriction, objection, portability or to lodge a complaint with a supervisory authority, please refer to our privacy policy.', 'fp-privacy' ); ?></p>
 
 <h2><?php echo esc_html__( 'Last update', 'fp-privacy' ); ?></h2>
 <p><?php echo esc_html( sprintf( __( 'This policy was generated on %s.', 'fp-privacy' ), $last_generated ) ); ?></p>

--- a/fp-privacy-cookie-policy/templates/privacy-policy.php
+++ b/fp-privacy-cookie-policy/templates/privacy-policy.php
@@ -15,7 +15,18 @@ $dpo_name = isset( $options['dpo_name'] ) ? $options['dpo_name'] : '';
 $dpo_mail = isset( $options['dpo_email'] ) ? $options['dpo_email'] : '';
 $privacy_mail = isset( $options['privacy_email'] ) ? $options['privacy_email'] : '';
 $vat      = isset( $options['vat'] ) ? $options['vat'] : '';
+$generated_at    = isset( $generated_at ) ? (int) $generated_at : 0;
 $categories_meta = isset( $categories_meta ) && is_array( $categories_meta ) ? $categories_meta : array();
+
+$date_format  = (string) get_option( 'date_format' );
+$time_format  = (string) get_option( 'time_format' );
+$display_date = trim( $date_format . ' ' . $time_format );
+
+if ( '' === $display_date ) {
+    $display_date = 'F j, Y';
+}
+
+$last_generated = $generated_at > 0 ? wp_date( $display_date, $generated_at ) : wp_date( $display_date );
 
 if ( ! function_exists( 'fp_privacy_format_service_cookies' ) ) {
     /**
@@ -98,6 +109,9 @@ if ( ! function_exists( 'fp_privacy_get_service_value' ) ) {
 }
 ?>
 <section class="fp-privacy-policy">
+<h2><?php echo esc_html__( 'Overview', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'This privacy policy explains how we process personal data in compliance with Regulation (EU) 2016/679 (General Data Protection Regulation, "GDPR") and applicable national privacy laws, including the most recent guidelines issued by European supervisory authorities.', 'fp-privacy' ); ?></p>
+
 <h2><?php echo esc_html__( 'Data controller', 'fp-privacy' ); ?></h2>
 <p>
 <?php echo esc_html( $org ); ?>
@@ -106,20 +120,35 @@ if ( ! function_exists( 'fp_privacy_get_service_value' ) ) {
 <?php if ( $privacy_mail ) : ?><?php echo esc_html( sprintf( __( 'Contact: %s', 'fp-privacy' ), $privacy_mail ) ); ?><?php endif; ?>
 </p>
 
+<h2><?php echo esc_html__( 'Applicable regulations', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'Processing activities are carried out in accordance with the GDPR, the ePrivacy Directive as implemented locally, consumer protection rules and any sector-specific obligations that apply to our services.', 'fp-privacy' ); ?></p>
+
+<h2><?php echo esc_html__( 'Categories of data we process', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'Depending on how you interact with the website we may process identification data (such as name or contact details), technical data (IP address, device identifiers, logs), usage data (pages visited, actions taken), and preference data (consent choices, marketing preferences). Additional information collected by specific services is described in the integrations table below.', 'fp-privacy' ); ?></p>
+
 <h2><?php echo esc_html__( 'Purposes of processing', 'fp-privacy' ); ?></h2>
-<p><?php echo esc_html__( 'We process personal data to provide our services, ensure security, measure performance and deliver personalized experiences in accordance with the selected consent preferences.', 'fp-privacy' ); ?></p>
+<p><?php echo esc_html__( 'We process personal data to provide our services, respond to enquiries, ensure security, measure performance, improve our content and deliver tailored experiences only where you have granted the relevant consent.', 'fp-privacy' ); ?></p>
 
 <h2><?php echo esc_html__( 'Legal bases', 'fp-privacy' ); ?></h2>
-<p><?php echo esc_html__( 'Depending on the specific processing activity we rely on consent, contractual necessity or legitimate interest. Marketing and analytics tools are only activated after explicit consent.', 'fp-privacy' ); ?></p>
+<p><?php echo esc_html__( 'Processing is grounded on one or more of the following legal bases: consent (Article 6.1.a GDPR) for optional tools such as analytics or marketing cookies; contractual necessity (Article 6.1.b GDPR) when processing is required to provide requested services; compliance with legal obligations (Article 6.1.c GDPR); and legitimate interest (Article 6.1.f GDPR) for security, fraud prevention and essential analytics balanced against your rights. Optional tools are never activated before consent is granted.', 'fp-privacy' ); ?></p>
 
 <h2><?php echo esc_html__( 'Recipients and data transfers', 'fp-privacy' ); ?></h2>
-<p><?php echo esc_html__( 'Data may be shared with technology partners listed below. Transfers outside the EU/EEA are protected through adequacy decisions, Standard Contractual Clauses or equivalent safeguards.', 'fp-privacy' ); ?></p>
+<p><?php echo esc_html__( 'Data may be shared with technology partners listed below strictly for the purposes indicated. When partners are established outside the European Economic Area, transfers occur only where an adequacy decision is in place or through Standard Contractual Clauses and additional safeguards consistent with the recommendations of the European Data Protection Board.', 'fp-privacy' ); ?></p>
+
+<h2><?php echo esc_html__( 'Security measures', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'We apply technical and organisational measures such as encryption in transit, access controls, data minimisation and staff training to protect personal data against unauthorised access, alteration or disclosure.', 'fp-privacy' ); ?></p>
 
 <h2><?php echo esc_html__( 'Retention', 'fp-privacy' ); ?></h2>
-<p><?php echo esc_html__( 'Consent records are stored for the period required by law. Technical cookies follow the lifespan indicated in the cookie tables.', 'fp-privacy' ); ?></p>
+<p><?php echo esc_html__( 'Personal data are retained only for as long as necessary to fulfil the purposes stated above, comply with statutory retention duties or defend legal claims. Consent records are stored for the period required by law. Technical cookies follow the lifespan indicated in the cookie tables.', 'fp-privacy' ); ?></p>
 
 <h2><?php echo esc_html__( 'Data subject rights', 'fp-privacy' ); ?></h2>
-<p><?php echo esc_html__( 'You can request access, rectification, erasure, restriction, portability or object to processing by contacting us. You can withdraw consent at any time from the cookie preferences interface.', 'fp-privacy' ); ?></p>
+<p><?php echo esc_html__( 'You can exercise your rights to access, rectification, erasure, restriction, objection, portability and to withdraw consent at any time without affecting the lawfulness of processing prior to withdrawal. You also have the right not to be subject to decisions based solely on automated processing, including profiling, which produce legal effects concerning you or similarly significantly affect you.', 'fp-privacy' ); ?></p>
+
+<h2><?php echo esc_html__( 'How to exercise your rights', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'Submit your request via email or the dedicated contact form. We will respond within one month pursuant to Articles 12 and 15–22 GDPR and may request additional information to verify your identity. If your request is complex or we receive numerous requests, the response time may be extended by two further months with prior notice.', 'fp-privacy' ); ?></p>
+
+<h2><?php echo esc_html__( 'Withdrawal of consent and cookie management', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html__( 'You can adjust your consent choices at any time through the cookie preferences interface displayed on the site footer or by clearing cookies in your browser. Revoking consent does not affect mandatory processing necessary to operate the service.', 'fp-privacy' ); ?></p>
 
 <?php if ( $dpo_name || $dpo_mail ) : ?>
 <h2><?php echo esc_html__( 'Data Protection Officer', 'fp-privacy' ); ?></h2>
@@ -186,9 +215,9 @@ if ( ! function_exists( 'fp_privacy_get_service_value' ) ) {
 </div>
 <?php endforeach; ?>
 
-<h2><?php echo esc_html__( 'How to exercise your rights', 'fp-privacy' ); ?></h2>
-<p><?php echo esc_html__( 'Submit your request via email or the dedicated contact form. We will respond within one month and may request additional information to verify your identity.', 'fp-privacy' ); ?></p>
-
 <h2><?php echo esc_html__( 'Supervisory authority', 'fp-privacy' ); ?></h2>
-<p><?php echo esc_html__( 'If you believe your privacy rights have been violated you can lodge a complaint with the competent supervisory authority.', 'fp-privacy' ); ?></p>
+<p><?php echo esc_html__( 'If you believe your privacy rights have been violated you can lodge a complaint with the competent supervisory authority in your Member State of residence, workplace or where the alleged infringement took place.', 'fp-privacy' ); ?></p>
+
+<h2><?php echo esc_html__( 'Last update', 'fp-privacy' ); ?></h2>
+<p><?php echo esc_html( sprintf( __( 'This policy was generated on %s.', 'fp-privacy' ), $last_generated ) ); ?></p>
 </section>


### PR DESCRIPTION
## Summary
- watch consent placeholders for dynamically injected embeds so blocked content resumes once consent changes
- seed script blocking rules from known detectors, persist managed presets during audits and regeneration, and expose the suggestions in settings
- email administrators about integration changes with configurable recipients and a daily cooldown toggle on the settings page

## Testing
- php -l fp-privacy-cookie-policy/src/Utils/Options.php
- php -l fp-privacy-cookie-policy/src/Admin/IntegrationAudit.php
- php -l fp-privacy-cookie-policy/src/Admin/Settings.php
- php -l fp-privacy-cookie-policy/src/Admin/PolicyEditor.php

------
https://chatgpt.com/codex/tasks/task_e_68e027880f60832fb355f9888a2ca903