### PR TITLE
Fix privacy plugin language defaults error

### DIFF
--- a/fp-privacy-cookie-policy/src/Utils/Options.php
+++ b/fp-privacy-cookie-policy/src/Utils/Options.php
@@ -88,12 +88,12 @@ class Options {
 	 */
 	private function __construct() {
 		$this->blog_id                = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
+		$this->script_rules_manager   = new ScriptRulesManager();
 		$this->options                = $this->load();
 		$this->language_normalizer    = new LanguageNormalizer( $this->get_languages() );
 		$this->auto_translator        = new AutoTranslator(
 			isset( $this->options['auto_translations'] ) ? $this->options['auto_translations'] : array()
 		);
-		$this->script_rules_manager   = new ScriptRulesManager();
 		$this->page_manager           = new PageManager( $this->language_normalizer );
 	}
 


### PR DESCRIPTION
Move `script_rules_manager` initialization to prevent a fatal error during plugin activation.

The `script_rules_manager` was being accessed via `$this->load()` before it was initialized in the `Options` class constructor, leading to a "Call to a member function build_language_defaults() on null" error. Moving its initialization ensures it's available when needed.

---
<a href="https://cursor.com/background-agent?bcId=bc-dce97c59-882b-45a4-b71d-0dd46ca2caa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dce97c59-882b-45a4-b71d-0dd46ca2caa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

