### PR TITLE
Check missing settings save

### DIFF
--- a/fp-privacy-cookie-policy/src/Admin/SettingsController.php
+++ b/fp-privacy-cookie-policy/src/Admin/SettingsController.php
@@ -210,27 +210,36 @@ class SettingsController {
 			$languages = array( \get_locale() );
 		}
 
-		$payload = array(
-			'languages_active'       => $languages,
-			'banner_texts'           => isset( $_POST['banner_texts'] ) ? \wp_unslash( $_POST['banner_texts'] ) : array(),
-			'banner_layout'          => isset( $_POST['banner_layout'] ) ? \wp_unslash( $_POST['banner_layout'] ) : array(),
-			'consent_mode_defaults'  => isset( $_POST['consent_mode_defaults'] ) ? \wp_unslash( $_POST['consent_mode_defaults'] ) : array(),
-			'gpc_enabled'            => isset( $_POST['gpc_enabled'] ),
-			'preview_mode'           => isset( $_POST['preview_mode'] ),
-			'org_name'               => isset( $_POST['org_name'] ) ? \wp_unslash( $_POST['org_name'] ) : '',
-			'vat'                    => isset( $_POST['vat'] ) ? \wp_unslash( $_POST['vat'] ) : '',
-			'address'                => isset( $_POST['address'] ) ? \wp_unslash( $_POST['address'] ) : '',
-			'dpo_name'               => isset( $_POST['dpo_name'] ) ? \wp_unslash( $_POST['dpo_name'] ) : '',
-			'dpo_email'              => isset( $_POST['dpo_email'] ) ? \wp_unslash( $_POST['dpo_email'] ) : '',
-			'privacy_email'          => isset( $_POST['privacy_email'] ) ? \wp_unslash( $_POST['privacy_email'] ) : '',
-			'categories'             => $this->options->get( 'categories' ),
-			'retention_days'         => isset( $_POST['retention_days'] ) ? (int) $_POST['retention_days'] : $this->options->get( 'retention_days' ),
-			'scripts'                => isset( $_POST['scripts'] ) ? \wp_unslash( $_POST['scripts'] ) : array(),
-			'detector_notifications' => array(
-				'email'      => isset( $_POST['detector_notifications']['email'] ),
-				'recipients' => isset( $_POST['detector_notifications']['recipients'] ) ? \wp_unslash( $_POST['detector_notifications']['recipients'] ) : '',
-			),
-		);
+	// Gestione banner_layout con enable_dark_mode
+	$banner_layout = isset( $_POST['banner_layout'] ) ? \wp_unslash( $_POST['banner_layout'] ) : array();
+	// Assicura che enable_dark_mode sia presente e booleano
+	if ( isset( $_POST['banner_layout']['enable_dark_mode'] ) ) {
+		$banner_layout['enable_dark_mode'] = true;
+	} else {
+		$banner_layout['enable_dark_mode'] = false;
+	}
+
+	$payload = array(
+		'languages_active'       => $languages,
+		'banner_texts'           => isset( $_POST['banner_texts'] ) ? \wp_unslash( $_POST['banner_texts'] ) : array(),
+		'banner_layout'          => $banner_layout,
+		'consent_mode_defaults'  => isset( $_POST['consent_mode_defaults'] ) ? \wp_unslash( $_POST['consent_mode_defaults'] ) : array(),
+		'gpc_enabled'            => isset( $_POST['gpc_enabled'] ),
+		'preview_mode'           => isset( $_POST['preview_mode'] ),
+		'org_name'               => isset( $_POST['org_name'] ) ? \wp_unslash( $_POST['org_name'] ) : '',
+		'vat'                    => isset( $_POST['vat'] ) ? \wp_unslash( $_POST['vat'] ) : '',
+		'address'                => isset( $_POST['address'] ) ? \wp_unslash( $_POST['address'] ) : '',
+		'dpo_name'               => isset( $_POST['dpo_name'] ) ? \wp_unslash( $_POST['dpo_name'] ) : '',
+		'dpo_email'              => isset( $_POST['dpo_email'] ) ? \wp_unslash( $_POST['dpo_email'] ) : '',
+		'privacy_email'          => isset( $_POST['privacy_email'] ) ? \wp_unslash( $_POST['privacy_email'] ) : '',
+		'categories'             => $this->options->get( 'categories' ),
+		'retention_days'         => isset( $_POST['retention_days'] ) ? (int) $_POST['retention_days'] : $this->options->get( 'retention_days' ),
+		'scripts'                => isset( $_POST['scripts'] ) ? \wp_unslash( $_POST['scripts'] ) : array(),
+		'detector_notifications' => array(
+			'email'      => isset( $_POST['detector_notifications']['email'] ),
+			'recipients' => isset( $_POST['detector_notifications']['recipients'] ) ? \wp_unslash( $_POST['detector_notifications']['recipients'] ) : '',
+		),
+	);
 
 		$this->options->set( $payload );
 

--- a/fp-privacy-cookie-policy/src/Admin/SettingsController.php
+++ b/fp-privacy-cookie-policy/src/Admin/SettingsController.php
@@ -210,19 +210,10 @@ class SettingsController {
 			$languages = array( \get_locale() );
 		}
 
-	// Gestione banner_layout con enable_dark_mode
-	$banner_layout = isset( $_POST['banner_layout'] ) ? \wp_unslash( $_POST['banner_layout'] ) : array();
-	// Assicura che enable_dark_mode sia presente e booleano
-	if ( isset( $_POST['banner_layout']['enable_dark_mode'] ) ) {
-		$banner_layout['enable_dark_mode'] = true;
-	} else {
-		$banner_layout['enable_dark_mode'] = false;
-	}
-
 	$payload = array(
 		'languages_active'       => $languages,
 		'banner_texts'           => isset( $_POST['banner_texts'] ) ? \wp_unslash( $_POST['banner_texts'] ) : array(),
-		'banner_layout'          => $banner_layout,
+		'banner_layout'          => isset( $_POST['banner_layout'] ) ? \wp_unslash( $_POST['banner_layout'] ) : array(),
 		'consent_mode_defaults'  => isset( $_POST['consent_mode_defaults'] ) ? \wp_unslash( $_POST['consent_mode_defaults'] ) : array(),
 		'gpc_enabled'            => isset( $_POST['gpc_enabled'] ),
 		'preview_mode'           => isset( $_POST['preview_mode'] ),

--- a/fp-privacy-cookie-policy/src/Utils/Options.php
+++ b/fp-privacy-cookie-policy/src/Utils/Options.php
@@ -235,12 +235,13 @@ class Options {
 			'banner_texts'          => array(
 				$default_locale => $banner_default,
 			),
-			'banner_layout'         => array(
-				'type'                  => 'floating',
-				'position'              => 'bottom',
-				'palette'               => $default_palette,
-				'sync_modal_and_button' => true,
-			),
+		'banner_layout'         => array(
+			'type'                  => 'floating',
+			'position'              => 'bottom',
+			'palette'               => $default_palette,
+			'sync_modal_and_button' => true,
+			'enable_dark_mode'      => false,
+		),
 			'categories'            => $category_defaults,
 			'consent_mode_defaults' => array(
 				'analytics_storage'       => 'denied',
@@ -317,12 +318,13 @@ class Options {
 			)
 		);
 
-		$layout = array(
-			'type'                  => Validator::choice( $layout_raw['type'] ?? '', array( 'floating', 'bar' ), $defaults['banner_layout']['type'] ),
-			'position'              => Validator::choice( $layout_raw['position'] ?? '', array( 'top', 'bottom' ), $defaults['banner_layout']['position'] ),
-			'palette'               => Validator::sanitize_palette( isset( $layout_raw['palette'] ) && \is_array( $layout_raw['palette'] ) ? $layout_raw['palette'] : array(), $defaults['banner_layout']['palette'] ),
-			'sync_modal_and_button' => Validator::bool( $layout_raw['sync_modal_and_button'] ?? $defaults['banner_layout']['sync_modal_and_button'] ),
-		);
+	$layout = array(
+		'type'                  => Validator::choice( $layout_raw['type'] ?? '', array( 'floating', 'bar' ), $defaults['banner_layout']['type'] ),
+		'position'              => Validator::choice( $layout_raw['position'] ?? '', array( 'top', 'bottom' ), $defaults['banner_layout']['position'] ),
+		'palette'               => Validator::sanitize_palette( isset( $layout_raw['palette'] ) && \is_array( $layout_raw['palette'] ) ? $layout_raw['palette'] : array(), $defaults['banner_layout']['palette'] ),
+		'sync_modal_and_button' => Validator::bool( $layout_raw['sync_modal_and_button'] ?? $defaults['banner_layout']['sync_modal_and_button'] ),
+		'enable_dark_mode'      => Validator::bool( $layout_raw['enable_dark_mode'] ?? ( $defaults['banner_layout']['enable_dark_mode'] ?? false ) ),
+	);
 
 		$default_categories = Validator::sanitize_categories( $defaults['categories'], $languages );
 		$categories         = Validator::sanitize_categories( $categories_raw, $languages );


### PR DESCRIPTION
Add `enable_dark_mode` to `Options.php` defaults and sanitization to ensure correct saving and retrieval of the dark mode setting.

The `enable_dark_mode` checkbox value was not being persisted because it was missing from the default options and, crucially, from the sanitization process in `Options.php`. Although the `SettingsController` was passing the value, it was being stripped during sanitization, leading to the setting not being saved or loaded correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c75a627-9bf8-4d32-abe8-36c8af8d1e98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9c75a627-9bf8-4d32-abe8-36c8af8d1e98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

