### PR TITLE
Fix inaccessible settings save button

### DIFF
--- a/fp-privacy-cookie-policy/assets/css/admin.css
+++ b/fp-privacy-cookie-policy/assets/css/admin.css
@@ -476,6 +476,71 @@ margin-top: 20px;
     transform: translateY(-1px);
 }
 
+/* Bottone sticky di salvataggio */
+.fp-privacy-sticky-save {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    z-index: 9999;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(20px);
+    transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    pointer-events: none;
+}
+
+.fp-privacy-sticky-save.visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+    pointer-events: auto;
+}
+
+.fp-privacy-sticky-save .button-primary {
+    background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+    border: none;
+    padding: 14px 32px;
+    font-size: 16px;
+    font-weight: 600;
+    border-radius: 12px;
+    box-shadow: 0 8px 24px rgba(37, 99, 235, 0.4);
+    transition: all 0.2s ease;
+    color: #ffffff;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.fp-privacy-sticky-save .button-primary::before {
+    content: '💾';
+    font-size: 20px;
+}
+
+.fp-privacy-sticky-save .button-primary:hover {
+    background: linear-gradient(135deg, #1d4ed8 0%, #1e40af 100%);
+    box-shadow: 0 12px 32px rgba(37, 99, 235, 0.5);
+    transform: translateY(-2px) scale(1.02);
+}
+
+.fp-privacy-sticky-save .button-primary:active {
+    transform: translateY(0) scale(0.98);
+}
+
+/* Animazione pulsante di salvataggio */
+@keyframes saveButtonPulse {
+    0%, 100% {
+        box-shadow: 0 8px 24px rgba(37, 99, 235, 0.4);
+    }
+    50% {
+        box-shadow: 0 8px 32px rgba(37, 99, 235, 0.6);
+    }
+}
+
+.fp-privacy-sticky-save .button-primary.pulse {
+    animation: saveButtonPulse 2s ease-in-out infinite;
+}
+
 /* Indicatore di salvataggio */
 .fp-privacy-saving-indicator {
     display: inline-flex;

--- a/fp-privacy-cookie-policy/assets/js/admin.js
+++ b/fp-privacy-cookie-policy/assets/js/admin.js
@@ -95,6 +95,61 @@ $( function () {
     // Auto-save indicator
     var autoSaveIndicator = $( '<div class="fp-privacy-saving-indicator"><div class="spinner"></div><span>Salvataggio...</span></div>' );
     form.find( '.button-primary' ).after( autoSaveIndicator );
+    
+    // Sticky save button
+    var originalButton = form.find( '.button-primary' );
+    var stickyContainer = $( '<div class="fp-privacy-sticky-save"></div>' );
+    var stickyButton = $( '<button type="button" class="button button-primary">Salva impostazioni</button>' );
+    stickyContainer.append( stickyButton );
+    $( 'body' ).append( stickyContainer );
+    
+    // Click handler per il bottone sticky
+    stickyButton.on( 'click', function() {
+        // Scrolla al bottone originale e cliccalo
+        $( 'html, body' ).animate({
+            scrollTop: originalButton.offset().top - 100
+        }, 500, function() {
+            originalButton.click();
+        });
+    });
+    
+    // Mostra/nascondi il bottone sticky durante lo scroll
+    var scrollTimeout;
+    var formBottom = form.offset().top + form.outerHeight();
+    
+    $( window ).on( 'scroll', function() {
+        clearTimeout( scrollTimeout );
+        
+        scrollTimeout = setTimeout( function() {
+            var scrollTop = $( window ).scrollTop();
+            var windowHeight = $( window ).height();
+            var documentHeight = $( document ).height();
+            
+            // Calcola se il bottone originale è visibile
+            var buttonTop = originalButton.offset().top;
+            var buttonBottom = buttonTop + originalButton.outerHeight();
+            var isButtonVisible = buttonTop < ( scrollTop + windowHeight ) && buttonBottom > scrollTop;
+            
+            // Mostra il bottone sticky solo se:
+            // 1. L'utente ha scrollato oltre una certa soglia (200px)
+            // 2. Il bottone originale non è visibile
+            // 3. Non siamo in fondo alla pagina
+            if ( scrollTop > 200 && ! isButtonVisible && ( scrollTop + windowHeight ) < ( documentHeight - 50 ) ) {
+                stickyContainer.addClass( 'visible' );
+                
+                // Aggiungi un effetto pulse se l'utente ha scrollato molto
+                if ( scrollTop > 500 ) {
+                    stickyButton.addClass( 'pulse' );
+                }
+            } else {
+                stickyContainer.removeClass( 'visible' );
+                stickyButton.removeClass( 'pulse' );
+            }
+        }, 50 );
+    });
+    
+    // Trigger iniziale
+    $( window ).trigger( 'scroll' );
 
     function evaluateContrast() {
         var surface = form.find( 'input[name="banner_layout[palette][surface_bg]"]' ).val();


### PR DESCRIPTION
Add a sticky save button to settings pages to ensure the save functionality is always accessible.

The original save button at the end of long settings forms can scroll out of view, making it difficult for users to find and click it. This change introduces a floating "Save settings" button that appears when the user scrolls past the original button, providing a persistent way to save changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4ded865-9d43-40b0-b439-af2798522231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b4ded865-9d43-40b0-b439-af2798522231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

