### PR TITLE
Fix black on black text visibility

### DIFF
--- a/fp-privacy-cookie-policy/assets/css/admin.css
+++ b/fp-privacy-cookie-policy/assets/css/admin.css
@@ -257,10 +257,27 @@ margin-right: 20px;
     border-radius: 8px;
     overflow: hidden;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    margin-top: 16px;
 }
 
 .fp-privacy-detected thead {
     background: linear-gradient(135deg, #1f2937 0%, #374151 100%);
+}
+
+/* Assicura che l'h2 prima della tabella detected sia ben visibile */
+.fp-privacy-settings h2:has(+ .fp-privacy-detected) {
+    background: #ffffff;
+    padding: 12px 16px;
+    margin-bottom: 0;
+    border-radius: 8px 8px 0 0;
+    color: #1f2937;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+/* Integra meglio la tabella con l'h2 sopra */
+.fp-privacy-settings h2:has(+ .fp-privacy-detected) + .fp-privacy-detected {
+    border-radius: 0 0 8px 8px;
+    margin-top: 0;
 }
 
 .fp-privacy-detected thead th {


### PR DESCRIPTION
Fix unreadable 'Detected services' header text by adding a white background and integrating it visually with the table.

---
<a href="https://cursor.com/background-agent?bcId=bc-777febe7-b39d-4b47-8290-338a63fd300b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-777febe7-b39d-4b47-8290-338a63fd300b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

