### PR TITLE
Implement bilingual modal with policy links

### DIFF
--- a/fp-privacy-cookie-policy/assets/css/banner.css
+++ b/fp-privacy-cookie-policy/assets/css/banner.css
@@ -262,7 +262,7 @@ color: #111827;
 max-width: 720px;
 width: 100%;
 border-radius: 12px;
-padding: 2rem;
+padding: 1.25rem;
 box-shadow: 0 20px 40px rgba(15, 23, 42, 0.3);
 position: relative;
 z-index: 2147483647;
@@ -290,6 +290,20 @@ body.fp-privacy-dark-mode-enabled .fp-privacy-modal {
 
 .fp-privacy-modal h2 {
 margin-top: 0;
+margin-bottom: 0.5rem;
+font-size: 1.25rem;
+}
+
+.fp-privacy-modal-links {
+display: flex;
+gap: 1rem;
+margin-bottom: 0.75rem;
+font-size: 0.875rem;
+}
+
+.fp-privacy-modal p {
+font-size: 0.875rem;
+margin-bottom: 0.5rem;
 }
 
 .fp-privacy-modal button.close {
@@ -306,8 +320,8 @@ color: inherit;
 .fp-privacy-category {
 border: 1px solid #e5e7eb;
 border-radius: 8px;
-padding: 1rem;
-margin-bottom: 1rem;
+padding: 0.75rem;
+margin-bottom: 0.75rem;
 transition: all 0.2s ease;
 }
 
@@ -328,6 +342,8 @@ body.fp-privacy-dark-mode-enabled .fp-privacy-category:hover {
 
 .fp-privacy-category h3 {
 margin-top: 0;
+margin-bottom: 0.4rem;
+font-size: 1rem;
 }
 
 .fp-privacy-switch {
@@ -369,8 +385,8 @@ transform: translateX(20px);
 
 .fp-privacy-modal-actions {
 display: flex;
-gap: 12px;
-margin-top: 1.5rem;
+gap: 10px;
+margin-top: 1rem;
 flex-wrap: wrap;
 }
 

--- a/fp-privacy-cookie-policy/assets/js/banner.js
+++ b/fp-privacy-cookie-policy/assets/js/banner.js
@@ -534,6 +534,35 @@ heading.id = 'fp-privacy-modal-title';
 modal.appendChild( heading );
 modal.setAttribute( 'aria-labelledby', heading.id );
 
+    // Add policy links
+    var policyUrls = data.options.policy_urls || {};
+    if ( policyUrls.privacy || policyUrls.cookie ) {
+        var linksWrapper = document.createElement( 'div' );
+        linksWrapper.className = 'fp-privacy-modal-links';
+        
+        if ( policyUrls.privacy ) {
+            var privacyLink = document.createElement( 'a' );
+            privacyLink.href = policyUrls.privacy;
+            privacyLink.className = 'fp-privacy-link';
+            privacyLink.setAttribute( 'target', '_blank' );
+            privacyLink.rel = 'noopener noreferrer';
+            privacyLink.textContent = texts.link_privacy_policy || 'Privacy Policy';
+            linksWrapper.appendChild( privacyLink );
+        }
+        
+        if ( policyUrls.cookie ) {
+            var cookieLink = document.createElement( 'a' );
+            cookieLink.href = policyUrls.cookie;
+            cookieLink.className = 'fp-privacy-link';
+            cookieLink.setAttribute( 'target', '_blank' );
+            cookieLink.rel = 'noopener noreferrer';
+            cookieLink.textContent = texts.link_cookie_policy || 'Cookie Policy';
+            linksWrapper.appendChild( cookieLink );
+        }
+        
+        modal.appendChild( linksWrapper );
+    }
+
     var savedCategories = state.categories || {};
 
     for ( var key in categories ) {

--- a/fp-privacy-cookie-policy/languages/fp-privacy-it_IT.po
+++ b/fp-privacy-cookie-policy/languages/fp-privacy-it_IT.po
@@ -921,6 +921,38 @@ msgstr "Apri Strumenti"
 msgid "We have updated our policy. Please review your preferences."
 msgstr "Abbiamo aggiornato la nostra policy. Rivedi le tue preferenze."
 
+#: src/Utils/Options.php:196
+msgid "Always active"
+msgstr "Sempre attivo"
+
+#: src/Utils/Options.php:197
+msgid "Enabled"
+msgstr "Abilitato"
+
+#: src/Utils/Options.php:192
+msgid "Privacy preferences"
+msgstr "Preferenze privacy"
+
+#: src/Utils/Options.php:193
+msgid "Close preferences"
+msgstr "Chiudi preferenze"
+
+#: src/Utils/Options.php:194
+msgid "Save preferences"
+msgstr "Salva preferenze"
+
+#: src/Utils/Options.php:198
+msgid "Cookie debug:"
+msgstr "Debug cookie:"
+
+#: src/Utils/Options.php:200
+msgid "Privacy Policy"
+msgstr "Informativa sulla Privacy"
+
+#: src/Utils/Options.php:201
+msgid "Cookie Policy"
+msgstr "Cookie Policy"
+
 #: assets/js/admin.js:51
 msgid "Update the banner texts above to preview the banner."
 msgstr "Aggiorna i testi del banner sopra per visualizzarne l'anteprima."

--- a/fp-privacy-cookie-policy/src/Frontend/ConsentState.php
+++ b/fp-privacy-cookie-policy/src/Frontend/ConsentState.php
@@ -84,6 +84,12 @@ $this->log_model = $log_model;
 
         $text       = $this->options->get_banner_text( $requested );
         $categories = $this->options->get_categories_for_language( $normalized );
+        
+        // Get policy page URLs
+        $privacy_page_id = $this->options->get_page_id( 'privacy_policy_page_id', $normalized );
+        $cookie_page_id = $this->options->get_page_id( 'cookie_policy_page_id', $normalized );
+        $privacy_url = $privacy_page_id ? \get_permalink( $privacy_page_id ) : '';
+        $cookie_url = $cookie_page_id ? \get_permalink( $cookie_page_id ) : '';
 
         return array(
             'texts'     => $text,
@@ -91,6 +97,10 @@ $this->log_model = $log_model;
             'categories'=> $categories,
             'state'     => $states,
             'mode'      => $this->options->get( 'consent_mode_defaults' ),
+            'policy_urls' => array(
+                'privacy' => $privacy_url,
+                'cookie' => $cookie_url,
+            ),
         );
     }
 

--- a/fp-privacy-cookie-policy/src/Utils/Options.php
+++ b/fp-privacy-cookie-policy/src/Utils/Options.php
@@ -197,6 +197,8 @@ class Options {
 			'toggle_enabled' => \__( 'Enabled', 'fp-privacy' ),
 			'debug_label'    => \__( 'Cookie debug:', 'fp-privacy' ),
 			'link_policy'    => '',
+			'link_privacy_policy' => \__( 'Privacy Policy', 'fp-privacy' ),
+			'link_cookie_policy'  => \__( 'Cookie Policy', 'fp-privacy' ),
 		);
 
 		$category_defaults = array(


### PR DESCRIPTION
Translate the cookie consent modal to Italian, add links to Privacy and Cookie Policy pages, and optimize layout to prevent scrolling.

The modal was a mix of Italian and English, lacked direct links to policy pages, and required scrolling on some screens. This PR addresses these issues by translating all strings, integrating policy links, and adjusting CSS for a compact, scroll-free display.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d5a5b9a-a00d-4642-9434-4eda6a89918f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8d5a5b9a-a00d-4642-9434-4eda6a89918f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

