### PR TITLE
Organize mobile buttons for better layout

### DIFF
--- a/fp-privacy-cookie-policy/assets/css/banner.css
+++ b/fp-privacy-cookie-policy/assets/css/banner.css
@@ -438,12 +438,21 @@ border-radius: 8px;
     }
     
     .fp-privacy-banner-buttons {
-        flex-direction: column;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 10px;
     }
     
     .fp-privacy-banner-buttons .fp-privacy-button {
         width: 100%;
         text-align: center;
+        padding: 0.65rem 1rem;
+        font-size: 0.9rem;
+    }
+    
+    /* Il bottone delle preferenze (terzo bottone) occupa tutta la larghezza */
+    .fp-privacy-banner-buttons .fp-privacy-button:nth-child(3) {
+        grid-column: 1 / -1;
     }
 }
 
@@ -457,9 +466,13 @@ border-radius: 8px;
         font-size: 1rem;
     }
     
-    .fp-privacy-button {
-        padding: 0.5rem 1.2rem;
-        font-size: 0.9rem;
+    .fp-privacy-banner-buttons {
+        gap: 8px;
+    }
+    
+    .fp-privacy-banner-buttons .fp-privacy-button {
+        padding: 0.6rem 0.8rem;
+        font-size: 0.85rem;
     }
     
     .fp-privacy-reopen {


### PR DESCRIPTION
Reorganize cookie banner buttons on mobile using CSS Grid to improve layout, accessibility, and space efficiency.

The original layout stacked buttons vertically on mobile, consuming significant vertical space and making the primary actions less prominent. The new grid layout places "Accept all" and "Reject all" side-by-side, with "Manage preferences" below, creating a more compact and intuitive user experience across various mobile screen sizes.

---
<a href="https://cursor.com/background-agent?bcId=bc-a99f6874-70d9-4816-ab8d-3798b92a3a71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a99f6874-70d9-4816-ab8d-3798b92a3a71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

