### PR TITLE
Fix dark first row in settings table

### DIFF
--- a/fp-privacy-cookie-policy/assets/css/admin.css
+++ b/fp-privacy-cookie-policy/assets/css/admin.css
@@ -303,6 +303,16 @@ margin-right: 20px;
 .fp-privacy-detected tbody td {
     padding: 12px 16px;
     border-bottom: 1px solid #e5e7eb;
+    color: #1f2937;
+}
+
+/* Assicura che la prima riga del tbody abbia sempre lo sfondo chiaro e testo scuro */
+.fp-privacy-detected tbody tr:first-child {
+    background: #ffffff !important;
+}
+
+.fp-privacy-detected tbody tr:first-child td {
+    color: #1f2937 !important;
 }
 
 .fp-privacy-detected .status-detected {


### PR DESCRIPTION
Ensure the first row of the "Servizi rilevati" table has readable dark text on a white background.

The first row of the "Servizi rilevati" table in the settings had a dark background and dark text, making it unreadable. This PR fixes the styling to ensure proper contrast.

---
<a href="https://cursor.com/background-agent?bcId=bc-eaf5d0bd-e8be-44bd-827f-fc999ed3feb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eaf5d0bd-e8be-44bd-827f-fc999ed3feb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

